### PR TITLE
16 add initial GitHub actions workflow for ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: check where we are
-        run: echo $(ls /)
-        shell: bash
+      - name: fix Python command
+        run: apt-get instal python-is-python3
       - name: Install poetry
         uses: Gr1N/setup-poetry@v4
       - name: Install pluginadmin dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: Gr1N/setup-poetry@v4
       - name: Install pluginadmin dependencies
         run: poetry install
       - name: Check formatting

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: fix Python command
-        run: apt-get instal python-is-python3
+        run: apt-get install python-is-python3
       - name: Install poetry
         uses: Gr1N/setup-poetry@v4
       - name: Install pluginadmin dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,14 @@ on: push
 jobs:
   ci:
     runs-on: ubuntu-20.04
-    container: qgis/qgis:release-3_16
+    container:
+      image: qgis/qgis:release-3_16
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: check where we are
+        run: echo $(ls /)
+        shell: bash
       - name: Install poetry
         uses: Gr1N/setup-poetry@v4
       - name: Install pluginadmin dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: qgis_geonode CI
+
+on: push
+
+jobs:
+  ci:
+    runs-on: ubuntu-20.04
+    container: qgis/qgis:release-3_16
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2.0.0
+      - name: Install pluginadmin dependencies
+        run: poetry install
+      - name: Check formatting
+        run: poetry run black --check src/qgis_geonode

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install poetry
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: snok/install-poetry@v1.1.1
       - name: Install pluginadmin dependencies
         run: poetry install
       - name: Check formatting


### PR DESCRIPTION
This PR adds an initial github actions workflow for having Continuous Integration in this repo.

The proposed implementation just adds a linting step whereby [black](https://github.com/psf/black) is used to check the format of the code.

The proposed implementation uses the official QGIS docker image as a base container for running the workflow steps. This means that in the short term we will be able to expand on it to run automated tests

fixes #16 