### PR TITLE
Load GeoNode layers into QGIS

### DIFF
--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -34,6 +34,7 @@ class BriefGeonodeResource:
     pk: int
     uuid: uuid.UUID
     name: str
+    workspace: str
     resource_type: GeonodeResourceType
     title: str
     abstract: str
@@ -53,6 +54,7 @@ class BriefGeonodeResource:
         pk: int,
         uuid: uuid.UUID,
         name: str,
+        workspace: str,
         resource_type: GeonodeResourceType,
         title: str,
         abstract: str,
@@ -69,6 +71,7 @@ class BriefGeonodeResource:
         self.pk = pk
         self.uuid = uuid
         self.name = name
+        self.workspace = workspace
         self.resource_type = resource_type
         self.title = title
         self.abstract = abstract
@@ -89,6 +92,7 @@ class BriefGeonodeResource:
             pk=int(payload["pk"]),
             uuid=uuid.UUID(payload["uuid"]),
             name=payload.get("name", ""),
+            workspace=payload.get("workspace", ""),
             resource_type=_get_resource_type(payload),
             title=payload.get("title", ""),
             abstract=payload.get("abstract", ""),

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -236,7 +236,11 @@ class GeonodeClient(QObject):
         )
 
     def handle_layer_detail(self, payload: typing.Dict):
-        layer = GeonodeResource.from_api_response(payload["layer"], self.base_url)
+        layer = GeonodeResource.from_api_response(
+            payload["layer"],
+            self.base_url,
+            self.auth_config
+        )
         self.layer_detail_received.emit(layer)
 
     def handle_layer_style_list(self, payload: typing.Dict):
@@ -248,7 +252,13 @@ class GeonodeClient(QObject):
     def handle_map_list(self, payload: typing.Dict):
         maps = []
         for item in payload.get("maps", []):
-            maps.append(BriefGeonodeResource.from_api_response(item, self.base_url))
+            maps.append(
+                BriefGeonodeResource.from_api_response(
+                    item,
+                    self.base_url,
+                    self.auth_config
+                )
+            )
         self.map_list_received.emit(
             maps, payload["total"], payload["page"], payload["page_size"]
         )

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -99,7 +99,7 @@ class BriefGeonodeResource:
             gui_url=payload["detail_url"],
             published_date=_get_published_date(payload),
             temporal_extent=_get_temporal_extent(payload),
-            keywords=[k["name"] for k in payload.get("kaywords", [])],
+            keywords=[k["name"] for k in payload.get("keywords", [])],
             category=payload.get("category"),
             service_urls=cls.build_service_urls(geonode_base_url, payload)
         )

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -225,8 +225,8 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         layout = QVBoxLayout()
         for layer in layers:
             search_result_widget = SearchResultWidget(
-                self.message_bar,
-                geonode_resource=layer)
+                self.message_bar, geonode_resource=layer
+            )
             layout.addWidget(search_result_widget)
         scroll_container.setLayout(layout)
         self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -224,7 +224,9 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         scroll_container = QWidget()
         layout = QVBoxLayout()
         for layer in layers:
-            search_result_widget = SearchResultWidget(geonode_resource=layer)
+            search_result_widget = SearchResultWidget(
+                self.message_bar,
+                geonode_resource=layer)
             layout.addWidget(search_result_widget)
         scroll_container.setLayout(layout)
         self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -49,28 +49,35 @@ class SearchResultWidget(QWidget, WidgetUi):
         )
 
     def load_map_resource(self):
+        self.wms_btn.setEnabled(False)
+
         layer = QgsRasterLayer(
             self.geonode_resource.service_urls['wms'],
             self.geonode_resource.name,
             'wms')
 
         self.load_layer(layer)
+        self.wms_btn.setEnabled(True)
 
     def load_raster_layer(self):
+        self.wcs_btn.setEnabled(False)
         layer = QgsRasterLayer(
             self.geonode_resource.service_urls['wcs'],
             self.geonode_resource.name,
             'wcs')
 
         self.load_layer(layer)
+        self.wcs_btn.setEnabled(True)
 
     def load_vector_layer(self):
+        self.wfs_btn.setEnabled(False)
         layer = QgsVectorLayer(
             self.geonode_resource.service_urls['wfs'],
             self.geonode_resource.name,
             "WFS")
 
         self.load_layer(layer)
+        self.wfs_btn.setEnabled(True)
 
     def load_layer(self, layer):
         if not layer.isValid():

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -3,12 +3,7 @@ import os
 from qgis.PyQt.QtWidgets import QWidget
 from qgis.PyQt.uic import loadUiType
 
-from qgis.core import (
-    Qgis,
-    QgsProject,
-    QgsRasterLayer,
-    QgsVectorLayer
-)
+from qgis.core import Qgis, QgsProject, QgsRasterLayer, QgsVectorLayer
 
 from qgis.gui import QgsMessageBar
 
@@ -23,10 +18,10 @@ WidgetUi, _ = loadUiType(
 
 class SearchResultWidget(QWidget, WidgetUi):
     def __init__(
-            self,
-            message_bar: QgsMessageBar,
-            geonode_resource: BriefGeonodeResource,
-            parent=None
+        self,
+        message_bar: QgsMessageBar,
+        geonode_resource: BriefGeonodeResource,
+        parent=None,
     ):
         super().__init__(parent)
         self.setupUi(self)
@@ -40,21 +35,18 @@ class SearchResultWidget(QWidget, WidgetUi):
         self.wfs_btn.clicked.connect(self.load_vector_layer)
 
         self.wcs_btn.setEnabled(
-            self.geonode_resource.resource_type ==
-            GeonodeResourceType.RASTER_LAYER
+            self.geonode_resource.resource_type == GeonodeResourceType.RASTER_LAYER
         )
         self.wfs_btn.setEnabled(
-            self.geonode_resource.resource_type ==
-            GeonodeResourceType.VECTOR_LAYER
+            self.geonode_resource.resource_type == GeonodeResourceType.VECTOR_LAYER
         )
 
     def load_map_resource(self):
         self.wms_btn.setEnabled(False)
 
         layer = QgsRasterLayer(
-            self.geonode_resource.service_urls['wms'],
-            self.geonode_resource.name,
-            'wms')
+            self.geonode_resource.service_urls["wms"], self.geonode_resource.name, "wms"
+        )
 
         self.load_layer(layer)
         self.wms_btn.setEnabled(True)
@@ -62,9 +54,8 @@ class SearchResultWidget(QWidget, WidgetUi):
     def load_raster_layer(self):
         self.wcs_btn.setEnabled(False)
         layer = QgsRasterLayer(
-            self.geonode_resource.service_urls['wcs'],
-            self.geonode_resource.name,
-            'wcs')
+            self.geonode_resource.service_urls["wcs"], self.geonode_resource.name, "wcs"
+        )
 
         self.load_layer(layer)
         self.wcs_btn.setEnabled(True)
@@ -72,9 +63,8 @@ class SearchResultWidget(QWidget, WidgetUi):
     def load_vector_layer(self):
         self.wfs_btn.setEnabled(False)
         layer = QgsVectorLayer(
-            self.geonode_resource.service_urls['wfs'],
-            self.geonode_resource.name,
-            "WFS")
+            self.geonode_resource.service_urls["wfs"], self.geonode_resource.name, "WFS"
+        )
 
         self.load_layer(layer)
         self.wfs_btn.setEnabled(True)
@@ -83,9 +73,8 @@ class SearchResultWidget(QWidget, WidgetUi):
         if not layer.isValid():
             log("Problem loading the layer into QGIS")
             self.message_bar.pushMessage(
-                tr("Problem loading layer, couldn't "
-                   "add an invalid layer"),
-                level=Qgis.Critical
+                tr("Problem loading layer, couldn't " "add an invalid layer"),
+                level=Qgis.Critical,
             )
         else:
             QgsProject.instance().addMapLayer(layer)

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -3,9 +3,16 @@ import os
 from qgis.PyQt.QtWidgets import QWidget
 from qgis.PyQt.uic import loadUiType
 
+from qgis.core import (
+    QgsProject,
+    QgsRasterLayer,
+    QgsVectorLayer
+)
+
 from ..api_client import BriefGeonodeResource
 from ..resources import *
-
+from ..conf import connections_manager
+from ..utils import log, tr
 
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/search_result_widget.ui")
@@ -18,3 +25,62 @@ class SearchResultWidget(QWidget, WidgetUi):
         self.setupUi(self)
         self.name_la.setText(geonode_resource.title)
         self.description_la.setText(geonode_resource.abstract)
+        self.geonode_resource = geonode_resource
+
+        self.wms_btn.clicked.connect(self.wms_btn_clicked)
+        self.wfs_btn.clicked.connect(self.wfs_btn_clicked)
+
+    def wms_btn_clicked(self):
+        self.load_ogc_layer('wms')
+
+    def wfs_btn_clicked(self):
+        self.load_ogc_layer('wfs')
+
+    def load_ogc_layer(self, provider_key: str):
+        layer_uri = self.construct_ogc_uri(self.geonode_resource, provider_key)
+
+        if layer_uri == '':
+            return
+
+        if provider_key == 'wms' or provider_key == 'wcs':
+            layer = QgsRasterLayer(layer_uri, self.geonode_resource.name, provider_key)
+        elif provider_key == 'wfs':
+            layer = QgsVectorLayer(layer_uri, self.geonode_resource.name, "WFS")
+
+        if not layer.isValid():
+            log("Problem loading the layer into QGIS")
+        else:
+            QgsProject.instance().addMapLayer(layer)
+
+    def construct_ogc_uri(self, geonode_resource, provider_key):
+        # TODO need to use the layer url from the API. At the moment of writing this,
+        #  the url is not  available in the GeoNode layer API response.
+        connection = connections_manager.get_current_connection()
+
+        if provider_key == 'wms':
+            uri = 'crs={}&format={}&layers={}:{}&' \
+                  'styles&url={}/geoserver/ows'.format(
+                geonode_resource.crs.authid(),
+                'image/png',
+                geonode_resource.workspace,
+                geonode_resource.name,
+                connection.base_url
+            )
+
+        elif provider_key == 'wfs':
+            uri = '{}/geoserver/ows?service=WFS&' \
+                  'version=1.1.0&request=GetFeature&typename={}:{}'.format(
+                connection.base_url,
+                geonode_resource.workspace,
+                geonode_resource.name
+            )
+        elif provider_key == 'wcs':
+            uri = '{}/geoserver/ows?identifier={}:{}'.format(
+                connection.base_url,
+                geonode_resource.workspace,
+                geonode_resource.name
+            )
+        else:
+            return ''
+
+        return uri

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -4,14 +4,16 @@ from qgis.PyQt.QtWidgets import QWidget
 from qgis.PyQt.uic import loadUiType
 
 from qgis.core import (
+    Qgis,
     QgsProject,
     QgsRasterLayer,
     QgsVectorLayer
 )
 
+from qgis.gui import QgsMessageBar
+
 from ..api_client import BriefGeonodeResource
 from ..resources import *
-from ..conf import connections_manager
 from ..utils import log, tr
 
 WidgetUi, _ = loadUiType(
@@ -20,12 +22,18 @@ WidgetUi, _ = loadUiType(
 
 
 class SearchResultWidget(QWidget, WidgetUi):
-    def __init__(self, geonode_resource: BriefGeonodeResource, parent=None):
+    def __init__(
+            self,
+            message_bar: QgsMessageBar,
+            geonode_resource: BriefGeonodeResource,
+            parent=None
+    ):
         super().__init__(parent)
         self.setupUi(self)
         self.name_la.setText(geonode_resource.title)
         self.description_la.setText(geonode_resource.abstract)
         self.geonode_resource = geonode_resource
+        self.message_bar = message_bar
 
         self.wms_btn.clicked.connect(self.wms_btn_clicked)
         self.wfs_btn.clicked.connect(self.wfs_btn_clicked)
@@ -37,9 +45,16 @@ class SearchResultWidget(QWidget, WidgetUi):
         self.load_ogc_layer('wfs')
 
     def load_ogc_layer(self, provider_key: str):
-        layer_uri = self.construct_ogc_uri(self.geonode_resource, provider_key)
+        layer_uri = self.geonode_resource.service_urls[provider_key]
 
         if layer_uri == '':
+            log("Problem loading the layer into QGIS, "
+                "couldn't create layer URI")
+            self.message_bar.pushMessage(
+                tr("Problem loading layer, couldn't "
+                   "create layer URI"),
+                level=Qgis.Critical
+            )
             return
 
         if provider_key == 'wms' or provider_key == 'wcs':
@@ -49,38 +64,10 @@ class SearchResultWidget(QWidget, WidgetUi):
 
         if not layer.isValid():
             log("Problem loading the layer into QGIS")
+            self.message_bar.pushMessage(
+                tr("Problem loading layer, couldn't "
+                   "add an invalid layer"),
+                level=Qgis.Critical
+            )
         else:
             QgsProject.instance().addMapLayer(layer)
-
-    def construct_ogc_uri(self, geonode_resource, provider_key):
-        # TODO need to use the layer url from the API. At the moment of writing this,
-        #  the url is not  available in the GeoNode layer API response.
-        connection = connections_manager.get_current_connection()
-
-        if provider_key == 'wms':
-            uri = 'crs={}&format={}&layers={}:{}&' \
-                  'styles&url={}/geoserver/ows'.format(
-                geonode_resource.crs.authid(),
-                'image/png',
-                geonode_resource.workspace,
-                geonode_resource.name,
-                connection.base_url
-            )
-
-        elif provider_key == 'wfs':
-            uri = '{}/geoserver/ows?service=WFS&' \
-                  'version=1.1.0&request=GetFeature&typename={}:{}'.format(
-                connection.base_url,
-                geonode_resource.workspace,
-                geonode_resource.name
-            )
-        elif provider_key == 'wcs':
-            uri = '{}/geoserver/ows?identifier={}:{}'.format(
-                connection.base_url,
-                geonode_resource.workspace,
-                geonode_resource.name
-            )
-        else:
-            return ''
-
-        return uri

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -63,7 +63,7 @@
         <item>
          <widget class="QPushButton" name="wms_btn">
           <property name="toolTip">
-           <string>Save connections to file</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to load resource as a WMS layer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>WMS</string>
@@ -73,7 +73,7 @@
         <item>
          <widget class="QPushButton" name="wfs_btn">
           <property name="toolTip">
-           <string>Save connections to file</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to load as a WFS layer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>WFS</string>

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -46,7 +46,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
@@ -77,6 +77,16 @@
           </property>
           <property name="text">
            <string>WFS</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="wcs_btn">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to load resource as a WMS layer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>WCS</string>
           </property>
          </widget>
         </item>

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -83,7 +83,7 @@
         <item>
          <widget class="QPushButton" name="download_btn">
           <property name="toolTip">
-           <string>Load connections from file</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Direct download&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>File Download</string>
@@ -106,7 +106,7 @@
         <item>
          <widget class="QPushButton" name="browser_btn">
           <property name="toolTip">
-           <string>Save connections to file</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open resource in Browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>Open in Browser</string>
@@ -116,7 +116,7 @@
         <item>
          <widget class="QPushButton" name="remove_btn">
           <property name="toolTip">
-           <string>Save connections to file</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delete the resource from GeoNode repository&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>Remove from Geonode</string>


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/56

This PR adds functionality for loading the GeoNode layer search results as QGIS layers.
 It would have been nice if we could determine from API layer response if the search result layers types so as to know whether to enable or disable the "WFS"/"WCS" buttons, at the moment there is no way to know about the layer type.

![loading_layers](https://user-images.githubusercontent.com/2663775/105847771-1a6b6380-5fef-11eb-94b2-fcf8dd50c32c.gif)
