### PR TITLE
Adding metadata into the QGIS layer

### DIFF
--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -36,7 +36,6 @@ class BriefGeonodeResource:
     resource_type: GeonodeResourceType
     title: str
     abstract: str
-    language: str
     published_date: typing.Optional[dt.datetime]
     spatial_extent: QgsRectangle
     temporal_extent: typing.Optional[typing.List[dt.datetime]]
@@ -44,12 +43,8 @@ class BriefGeonodeResource:
     thumbnail_url: str
     api_url: str
     gui_url: str
-    license: str
-    constraints: str
     keywords: typing.List[str]
     category: typing.Optional[str]
-    owner: typing.Dict[str, str]
-    metadata_author: typing.Dict[str, str]
     service_urls: typing.Dict[str, str]
 
     def __init__(
@@ -60,20 +55,15 @@ class BriefGeonodeResource:
         resource_type: GeonodeResourceType,
         title: str,
         abstract: str,
-        language: str,
         spatial_extent: QgsRectangle,
         crs: QgsCoordinateReferenceSystem,
         thumbnail_url: str,
         api_url: str,
         gui_url: str,
-        license: str,
-        constraints: str,
         published_date: typing.Optional[dt.datetime] = None,
         temporal_extent: typing.Optional[typing.List[dt.datetime]] = None,
         keywords: typing.Optional[typing.List[str]] = None,
         category: typing.Optional[str] = None,
-        owner: typing.Dict[str, str] = None,
-        metadata_author: typing.Dict[str, str] = None,
         service_urls: typing.Dict[str, str] = None,
     ):
         self.pk = pk
@@ -82,7 +72,6 @@ class BriefGeonodeResource:
         self.resource_type = resource_type
         self.title = title
         self.abstract = abstract
-        self.language = language
         self.spatial_extent = spatial_extent
         self.crs = crs
         self.thumbnail_url = thumbnail_url
@@ -92,10 +81,6 @@ class BriefGeonodeResource:
         self.temporal_extent = temporal_extent
         self.keywords = list(keywords) if keywords is not None else []
         self.category = category
-        self.owner = owner
-        self.metadata_author = metadata_author
-        self.license = license
-        self.constraints = constraints
         self.service_urls = service_urls
 
     @classmethod
@@ -115,7 +100,6 @@ class BriefGeonodeResource:
             resource_type=resource_type,
             title=payload.get("title", ""),
             abstract=payload.get("abstract", ""),
-            language=payload.get("language", ""),
             spatial_extent=_get_spatial_extent(payload["bbox_polygon"]),
             crs=QgsCoordinateReferenceSystem(payload["srid"].replace("EPSG:", "")),
             thumbnail_url=payload["thumbnail_url"],
@@ -125,17 +109,67 @@ class BriefGeonodeResource:
             temporal_extent=_get_temporal_extent(payload),
             keywords=[k["name"] for k in payload.get("keywords", [])],
             category=payload.get("category", ""),
-            owner=payload.get("owner", ""),
-            metadata_author=payload.get("metadata_author", ""),
-            license=payload.get("license", ""),
-            constraints=payload.get("constraints_other", ""),
             service_urls=service_urls,
         )
 
 
-
 class GeonodeResource(BriefGeonodeResource):
-    pass
+    language: str
+    license: str
+    constraints: str
+    owner: typing.Dict[str, str]
+    metadata_author: typing.Dict[str, str]
+
+    def __init__(
+        self,
+        language: str,
+        license: str,
+        constraints: str,
+        owner: typing.Dict[str, str],
+        metadata_author: typing.Dict[str, str],
+        *args,
+        ** kwargs
+    ):
+        super(GeonodeResource, self).__init__(*args, **kwargs)
+        self.language = language
+        self.license = license
+        self.constraints = constraints
+        self.owner = owner
+        self.metadata_author = metadata_author
+
+    @classmethod
+    def from_api_response(
+            cls, payload: typing.Dict, geonode_base_url: str, auth_config: str
+    ):
+        # TODO use a better way to initialize superclass members
+        brief_resource = BriefGeonodeResource.from_api_response(
+            payload,
+            geonode_base_url,
+            auth_config
+        )
+        return cls(
+            language=payload.get("language", ""),
+            license=payload.get("license", ""),
+            constraints=payload.get("constraints_other", ""),
+            owner=payload.get("owner", ""),
+            metadata_author=payload.get("metadata_author", ""),
+            pk=brief_resource.pk,
+            uuid=brief_resource.uuid,
+            name=brief_resource.name,
+            resource_type=brief_resource.resource_type,
+            title=brief_resource.title,
+            abstract=brief_resource.abstract,
+            spatial_extent=brief_resource.spatial_extent,
+            crs=brief_resource.crs,
+            thumbnail_url=brief_resource.thumbnail_url,
+            api_url=brief_resource.api_url,
+            gui_url=brief_resource.gui_url,
+            published_date=brief_resource.published_date,
+            temporal_extent=brief_resource.temporal_extent,
+            keywords=brief_resource.keywords,
+            category=brief_resource.category,
+            service_urls=brief_resource.service_urls
+        )
 
 
 class BriefGeonodeStyle:

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -101,7 +101,7 @@ class BriefGeonodeResource:
             title=payload.get("title", ""),
             abstract=payload.get("abstract", ""),
             spatial_extent=_get_spatial_extent(payload["bbox_polygon"]),
-            crs=QgsCoordinateReferenceSystem(payload["srid"].replace("EPSG:", "")),
+            crs=QgsCoordinateReferenceSystem(payload["srid"]),
             thumbnail_url=payload["thumbnail_url"],
             api_url=f"{geonode_base_url}/api/v2/layers/{payload['pk']}",
             gui_url=payload["detail_url"],

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -36,6 +36,7 @@ class BriefGeonodeResource:
     resource_type: GeonodeResourceType
     title: str
     abstract: str
+    language: str
     published_date: typing.Optional[dt.datetime]
     spatial_extent: QgsRectangle
     temporal_extent: typing.Optional[typing.List[dt.datetime]]
@@ -55,6 +56,7 @@ class BriefGeonodeResource:
         resource_type: GeonodeResourceType,
         title: str,
         abstract: str,
+        language: str,
         spatial_extent: QgsRectangle,
         crs: QgsCoordinateReferenceSystem,
         thumbnail_url: str,
@@ -72,6 +74,7 @@ class BriefGeonodeResource:
         self.resource_type = resource_type
         self.title = title
         self.abstract = abstract
+        self.language = language
         self.spatial_extent = spatial_extent
         self.crs = crs
         self.thumbnail_url = thumbnail_url
@@ -100,6 +103,7 @@ class BriefGeonodeResource:
             resource_type=resource_type,
             title=payload.get("title", ""),
             abstract=payload.get("abstract", ""),
+            language=payload.get("language", ""),
             spatial_extent=_get_spatial_extent(payload["bbox_polygon"]),
             crs=QgsCoordinateReferenceSystem(payload["srid"].replace("EPSG:", "")),
             thumbnail_url=payload["thumbnail_url"],
@@ -111,6 +115,7 @@ class BriefGeonodeResource:
             category=payload.get("category"),
             service_urls=service_urls,
         )
+
 
 
 class GeonodeResource(BriefGeonodeResource):

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -44,8 +44,12 @@ class BriefGeonodeResource:
     thumbnail_url: str
     api_url: str
     gui_url: str
+    license: str
+    constraints: str
     keywords: typing.List[str]
     category: typing.Optional[str]
+    owner: typing.Dict[str, str]
+    metadata_author: typing.Dict[str, str]
     service_urls: typing.Dict[str, str]
 
     def __init__(
@@ -62,10 +66,14 @@ class BriefGeonodeResource:
         thumbnail_url: str,
         api_url: str,
         gui_url: str,
+        license: str,
+        constraints: str,
         published_date: typing.Optional[dt.datetime] = None,
         temporal_extent: typing.Optional[typing.List[dt.datetime]] = None,
         keywords: typing.Optional[typing.List[str]] = None,
         category: typing.Optional[str] = None,
+        owner: typing.Dict[str, str] = None,
+        metadata_author: typing.Dict[str, str] = None,
         service_urls: typing.Dict[str, str] = None,
     ):
         self.pk = pk
@@ -84,6 +92,10 @@ class BriefGeonodeResource:
         self.temporal_extent = temporal_extent
         self.keywords = list(keywords) if keywords is not None else []
         self.category = category
+        self.owner = owner
+        self.metadata_author = metadata_author
+        self.license = license
+        self.constraints = constraints
         self.service_urls = service_urls
 
     @classmethod
@@ -112,7 +124,11 @@ class BriefGeonodeResource:
             published_date=_get_published_date(payload),
             temporal_extent=_get_temporal_extent(payload),
             keywords=[k["name"] for k in payload.get("keywords", [])],
-            category=payload.get("category"),
+            category=payload.get("category", ""),
+            owner=payload.get("owner", ""),
+            metadata_author=payload.get("metadata_author", ""),
+            license=payload.get("license", ""),
+            constraints=payload.get("constraints_other", ""),
             service_urls=service_urls,
         )
 

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -77,4 +77,20 @@ class SearchResultWidget(QWidget, WidgetUi):
                 level=Qgis.Critical,
             )
         else:
+            self.populate_metadata(layer)
             QgsProject.instance().addMapLayer(layer)
+
+    def populate_metadata(self, layer):
+        metadata = layer.metadata()
+        metadata.setTitle(self.geonode_resource.title)
+        metadata.setAbstract(self.geonode_resource.abstract)
+        metadata.setLanguage(self.geonode_resource.language)
+        metadata.setKeywords(
+            {'layer': self.geonode_resource.keywords}
+        )
+        metadata.setCrs(self.geonode_resource.crs)
+        # metadata.extent().setSpatialExtents(
+        #     self.geonode_resource.spatial_extent)
+        # metadata.extent().setTemporalExtents(
+        #     self.geonode_resource.temporal_extent)
+        layer.setMetadata(metadata)

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -44,6 +44,9 @@ class SearchResultWidget(QWidget, WidgetUi):
         self.geonode_resource = geonode_resource
         self.message_bar = message_bar
 
+        connection = connections_manager.get_current_connection()
+        self.client = GeonodeClient.from_connection_settings(connection)
+
         self.wms_btn.clicked.connect(self.load_map_resource)
         self.wcs_btn.clicked.connect(self.load_raster_layer)
         self.wfs_btn.clicked.connect(self.load_vector_layer)
@@ -77,12 +80,9 @@ class SearchResultWidget(QWidget, WidgetUi):
 
     def load_layer(self, layer):
         if layer.isValid():
-            connection = connections_manager.get_current_connection()
-            client = GeonodeClient.from_connection_settings(connection)
-
             show_layer_handler = partial(self.show_layer, layer)
-            client.layer_detail_received.connect(show_layer_handler)
-            client.get_layer_detail(self.geonode_resource.pk)
+            self.client.layer_detail_received.connect(show_layer_handler)
+            self.client.get_layer_detail(self.geonode_resource.pk)
 
         else:
             log("Problem loading the layer into QGIS")

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -80,8 +80,8 @@ class SearchResultWidget(QWidget, WidgetUi):
             connection = connections_manager.get_current_connection()
             client = GeonodeClient.from_connection_settings(connection)
 
-            populate_metadata_handler = partial(self.show_layer, layer)
-            client.layer_detail_received.connect(populate_metadata_handler)
+            show_layer_handler = partial(self.show_layer, layer)
+            client.layer_detail_received.connect(show_layer_handler)
             client.get_layer_detail(self.geonode_resource.pk)
 
         else:


### PR DESCRIPTION
Populating QGIS layer loaded from the Geonode provider with metadata from GeoNode.

![layer_metadata](https://user-images.githubusercontent.com/2663775/106337647-c8526880-62a2-11eb-81f9-2fc1a0ef7220.gif)

fixes #57 
fixes #76