### PR TITLE
Added word wrapping on search result widget

### DIFF
--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -22,6 +22,9 @@
         <property name="text">
          <string>Resource</string>
         </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>
@@ -30,6 +33,9 @@
          <widget class="QLabel" name="description_la">
           <property name="text">
            <string>Description</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The search result widget was making the scroll area expand when any of the search result title or description are long, this is because there were no word wrapping setting in the title and description. This PR adds word wrap setting on the corresponding items.

Related to #66