### PR TITLE
Adding search filtering in the API client

### DIFF
--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -229,12 +229,27 @@ class GeonodeClient(QObject):
             auth_config=connection_settings.auth_config,
         )
 
-    def get_layers(self, page: typing.Optional[int] = None):
+    def get_layers(
+            self,
+            page: typing.Optional[int] = None,
+            filters: typing.Dict = None
+    ):
         url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.LAYER_LIST.value}")
         if page:
             query = QUrlQuery()
             query.addQueryItem("page", str(page))
             url.setQuery(query.query())
+
+        if filters:
+            query = QUrlQuery()
+            query.addQueryItem("format", "json")
+            url.setQuery(query.query())
+
+            for key in filters:
+                query = QUrlQuery()
+                query.addQueryItem(key, filters[key])
+                url.setQuery(query.query())
+
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_layer_list)
 
@@ -254,13 +269,28 @@ class GeonodeClient(QObject):
         )
         self.run_task(request, self.handle_layer_style_list)
 
-    def get_maps(self, page: typing.Optional[int] = None):
+    def get_maps(
+            self,
+            page: typing.Optional[int] = None,
+            filters: typing.Dict = None
+    ):
         """Slot to retrieve list of maps available in GeoNode"""
         url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.MAP_LIST.value}")
         if page:
             query = QUrlQuery()
             query.addQueryItem("page", str(page))
             url.setQuery(query.query())
+
+        if filters:
+            query = QUrlQuery()
+            query.addQueryItem("format", "json")
+            url.setQuery(query.query())
+
+            for key in filters:
+                query = QUrlQuery()
+                query.addQueryItem(key, filters[key])
+                url.setQuery(query.query())
+
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_map_list)
 

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -236,6 +236,7 @@ class GeonodeClient(QObject):
             topic_category: typing.Optional[str] = None,
             resource_type: GeonodeResourceType = None,
             page: typing.Optional[int] = None):
+        """Slot to retrieve list of layers available in GeoNode"""
         url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.LAYER_LIST.value}")
         query = QUrlQuery()
         if title:

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -276,25 +276,25 @@ class GeonodeClient(QObject):
 
     def get_maps(
             self,
-            page: typing.Optional[int] = None,
-            filters: typing.Dict = None
-    ):
+            title: typing.Optional[str] = None,
+            keywords: typing.Optional[str] = None,
+            topic_category: typing.Optional[str] = None,
+            page: typing.Optional[int] = None
+        ):
         """Slot to retrieve list of maps available in GeoNode"""
         url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.MAP_LIST.value}")
+        query = QUrlQuery()
+        if title:
+            query.addQueryItem("filter{title.icontains}", title)
+        if keywords:
+            query.addQueryItem("filter{keywords.name.icontains}", keywords)
+        if topic_category:
+            query.addQueryItem("filter{category.identifier}", topic_category)
+
         if page:
-            query = QUrlQuery()
             query.addQueryItem("page", str(page))
-            url.setQuery(query.query())
 
-        if filters:
-            query = QUrlQuery()
-            query.addQueryItem("format", "json")
-            url.setQuery(query.query())
-
-            for key in filters:
-                query = QUrlQuery()
-                query.addQueryItem(key, filters[key])
-                url.setQuery(query.query())
+        url.setQuery(query.query())
 
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_map_list)

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -231,25 +231,30 @@ class GeonodeClient(QObject):
 
     def get_layers(
             self,
-            page: typing.Optional[int] = None,
-            filters: typing.Dict = None
-    ):
+            title: typing.Optional[str] = None,
+            keywords: typing.Optional[str] = None,
+            topic_category: typing.Optional[str] = None,
+            resource_type: GeonodeResourceType = None,
+            page: typing.Optional[int] = None):
         url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.LAYER_LIST.value}")
+        query = QUrlQuery()
+        if title:
+            query.addQueryItem("filter{title.icontains}", title)
+        if keywords:
+            query.addQueryItem("filter{keywords.name.icontains}", keywords)
+        if topic_category:
+            query.addQueryItem("filter{category.identifier}", topic_category)
+        if resource_type:
+            if resource_type == GeonodeResourceType.RASTER_LAYER:
+                query.addQueryItem("filter{storeType}", "coverageStore")
+            elif resource_type == GeonodeResourceType.VECTOR_LAYER:
+                query.addQueryItem("filter{storeType}", "dataStore")
+            elif resource_type == GeonodeResourceType.MAP:
+                url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.MAP_LIST.value}")
         if page:
-            query = QUrlQuery()
             query.addQueryItem("page", str(page))
-            url.setQuery(query.query())
 
-        if filters:
-            query = QUrlQuery()
-            query.addQueryItem("format", "json")
-            url.setQuery(query.query())
-
-            for key in filters:
-                query = QUrlQuery()
-                query.addQueryItem(key, filters[key])
-                url.setQuery(query.query())
-
+        url.setQuery(query.query())
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_layer_list)
 

--- a/src/qgis_geonode/api_client.py
+++ b/src/qgis_geonode/api_client.py
@@ -230,34 +230,54 @@ class GeonodeClient(QObject):
         )
 
     def get_layers(
-            self,
-            title: typing.Optional[str] = None,
-            keywords: typing.Optional[str] = None,
-            topic_category: typing.Optional[str] = None,
-            resource_type: GeonodeResourceType = None,
-            page: typing.Optional[int] = None):
+        self,
+        title: typing.Optional[str] = None,
+        abstract: typing.Optional[str] = None,
+        keyword: typing.Optional[str] = None,
+        topic_category: typing.Optional[str] = None,
+        layer_type: typing.List[GeonodeResourceType] = None,
+        page: typing.Optional[int] = 1,
+    ):
         """Slot to retrieve list of layers available in GeoNode"""
         url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.LAYER_LIST.value}")
         query = QUrlQuery()
-        if title:
+        query.addQueryItem("page", str(page))
+        if title is not None:
             query.addQueryItem("filter{title.icontains}", title)
-        if keywords:
-            query.addQueryItem("filter{keywords.name.icontains}", keywords)
-        if topic_category:
+        if abstract is not None:
+            query.addQueryItem("filter{abstract.icontains}", abstract)
+        if keyword is not None:  # TODO: Allow using multiple keywords
+            query.addQueryItem("filter{keywords.name.icontains}", keyword)
+        if topic_category is not None:
             query.addQueryItem("filter{category.identifier}", topic_category)
-        if resource_type:
-            if resource_type == GeonodeResourceType.RASTER_LAYER:
-                query.addQueryItem("filter{storeType}", "coverageStore")
-            elif resource_type == GeonodeResourceType.VECTOR_LAYER:
-                query.addQueryItem("filter{storeType}", "dataStore")
-            elif resource_type == GeonodeResourceType.MAP:
-                url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.MAP_LIST.value}")
-        if page:
-            query.addQueryItem("page", str(page))
-
+        if layer_type == GeonodeResourceType.RASTER_LAYER:
+            query.addQueryItem("filter{storeType}", "coverageStore")
+        elif layer_type == GeonodeResourceType.VECTOR_LAYER:
+            query.addQueryItem("filter{storeType}", "dataStore")
         url.setQuery(query.query())
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_layer_list)
+
+    def get_maps(
+        self,
+        title: typing.Optional[str] = None,
+        keyword: typing.Optional[str] = None,
+        topic_category: typing.Optional[str] = None,
+        page: typing.Optional[int] = 1,
+    ):
+        """Slot to retrieve list of maps available in GeoNode"""
+        url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.MAP_LIST.value}")
+        query = QUrlQuery()
+        query.addQueryItem("page", str(page))
+        if title:
+            query.addQueryItem("filter{title.icontains}", title)
+        if keyword:  # TODO: Allow using multiple keywords
+            query.addQueryItem("filter{keywords.name.icontains}", keyword)
+        if topic_category:
+            query.addQueryItem("filter{category.identifier}", topic_category)
+        url.setQuery(query.query())
+        request = QNetworkRequest(url)
+        self.run_task(request, self.handle_map_list)
 
     def get_layer_detail(self, id_: int):
         """Slot to retrieve layer details available in GeoNode"""
@@ -274,31 +294,6 @@ class GeonodeClient(QObject):
             )
         )
         self.run_task(request, self.handle_layer_style_list)
-
-    def get_maps(
-            self,
-            title: typing.Optional[str] = None,
-            keywords: typing.Optional[str] = None,
-            topic_category: typing.Optional[str] = None,
-            page: typing.Optional[int] = None
-        ):
-        """Slot to retrieve list of maps available in GeoNode"""
-        url = QUrl(f"{self.base_url}{GeonodeApiEndpoint.MAP_LIST.value}")
-        query = QUrlQuery()
-        if title:
-            query.addQueryItem("filter{title.icontains}", title)
-        if keywords:
-            query.addQueryItem("filter{keywords.name.icontains}", keywords)
-        if topic_category:
-            query.addQueryItem("filter{category.identifier}", topic_category)
-
-        if page:
-            query.addQueryItem("page", str(page))
-
-        url.setQuery(query.query())
-
-        request = QNetworkRequest(url)
-        self.run_task(request, self.handle_map_list)
 
     def run_task(self, request, handler: typing.Callable):
         """Fetches the response from the GeoNode API"""

--- a/test/_mock_geonode.py
+++ b/test/_mock_geonode.py
@@ -1,7 +1,10 @@
 import json
+import re
+import urllib.parse
+
 from pathlib import Path
 
-from flask import Flask
+from flask import Flask, request
 import flask.logging
 
 geonode_flask_app = Flask("mock_geonode")
@@ -10,11 +13,42 @@ geonode_flask_app.logger.removeHandler(flask.logging.default_handler)
 ROOT = Path(__file__).parent / "_mock_geonode_data"
 
 
+def _filter_json(data, resource_type, query_string):
+    query_string = urllib.parse.unquote(
+        query_string.decode("utf-8")
+    )
+
+    if "filter" not in query_string:
+        return data
+
+    pattern = re.compile("filter(.*)")
+    match = pattern.search(query_string)
+    filter_string = match.group(1)
+
+    # parsing the required field and value
+    # for filtering from the query string
+    filter_part = filter_string.split('=')
+    field_operator_string = filter_part[0]
+    field_operator_list = field_operator_string.split('.')
+    field = field_operator_list[0].replace('{', '').replace('}', '')
+    value = filter_part[1]
+
+    resources = [resource for resource in data[resource_type]
+                 if resource[field] == value]
+    data[resource_type] = resources
+    return data
+
+
 @geonode_flask_app.route("/api/v2/layers/")
 def _mock_layer_list():
     data_path = ROOT / "layer_list_response1.json"
     with data_path.open() as fh:
         result = json.load(fh)
+        result = _filter_json(
+            result,
+            "layers",
+            request.query_string
+        )
         return result
 
 
@@ -39,4 +73,9 @@ def _mock_map_list():
     data_path = ROOT / "map_list_response1.json"
     with data_path.open() as fh:
         result = json.load(fh)
+        result = _filter_json(
+            result,
+            "maps",
+            request.query_string
+        )
         return result

--- a/test/_mock_geonode.py
+++ b/test/_mock_geonode.py
@@ -13,42 +13,24 @@ geonode_flask_app.logger.removeHandler(flask.logging.default_handler)
 ROOT = Path(__file__).parent / "_mock_geonode_data"
 
 
-def _filter_json(data, resource_type, query_string):
-    query_string = urllib.parse.unquote(
-        query_string.decode("utf-8")
-    )
-
-    if "filter" not in query_string:
-        return data
-
-    pattern = re.compile("filter(.*)")
-    match = pattern.search(query_string)
-    filter_string = match.group(1)
-
-    # parsing the required field and value
-    # for filtering from the query string
-    filter_part = filter_string.split('=')
-    field_operator_string = filter_part[0]
-    field_operator_list = field_operator_string.split('.')
-    field = field_operator_list[0].replace('{', '').replace('}', '')
-    value = filter_part[1]
-
-    resources = [resource for resource in data[resource_type]
-                 if resource[field] == value]
-    data[resource_type] = resources
-    return data
-
-
 @geonode_flask_app.route("/api/v2/layers/")
 def _mock_layer_list():
-    data_path = ROOT / "layer_list_response1.json"
+    query_string = urllib.parse.unquote(
+        request.query_string.decode("utf-8")
+    )
+    if "filter" in query_string:
+        pattern = re.compile("filter(.*)")
+        match = pattern.search(query_string)
+        filter_string = match.group(1)
+        if filter_string:
+            data_path = ROOT / "layer_list_filtered_response1.json"
+        else:
+            data_path = ROOT / "layer_list_response1.json"
+    else:
+        data_path = ROOT / "layer_list_response1.json"
+
     with data_path.open() as fh:
         result = json.load(fh)
-        result = _filter_json(
-            result,
-            "layers",
-            request.query_string
-        )
         return result
 
 
@@ -70,12 +52,20 @@ def _mock_layer_styles(layer_id):
 
 @geonode_flask_app.route("/api/v2/maps/")
 def _mock_map_list():
-    data_path = ROOT / "map_list_response1.json"
+    query_string = urllib.parse.unquote(
+        request.query_string.decode("utf-8")
+    )
+    if "filter" in query_string:
+        pattern = re.compile("filter(.*)")
+        match = pattern.search(query_string)
+        filter_string = match.group(1)
+        if filter_string:
+            data_path = ROOT / "map_list_filtered_response1.json"
+        else:
+            data_path = ROOT / "map_list_response1.json"
+    else:
+        data_path = ROOT / "map_list_response1.json"
+
     with data_path.open() as fh:
         result = json.load(fh)
-        result = _filter_json(
-            result,
-            "maps",
-            request.query_string
-        )
         return result

--- a/test/_mock_geonode_data/layer_list_filtered_response1.json
+++ b/test/_mock_geonode_data/layer_list_filtered_response1.json
@@ -1,0 +1,145 @@
+{
+	"links": {
+		"next": "https://master.demo.geonode.org/api/v2/layers/?format=json&page=2&page_size=2",
+		"previous": null
+	},
+	"total": 121,
+	"page": 1,
+	"page_size": 2,
+	"layers": [{
+		"pk": "184",
+		"uuid": "818898b8-5c1a-11eb-b604-0242ac150007",
+		"name": "TEMPERATURASMINENERO2030",
+		"workspace": "geonode",
+		"store": "TEMPERATURASMINENERO2030",
+		"storeType": "coverageStore",
+		"charset": "UTF-8",
+		"is_mosaic": false,
+		"has_time": false,
+		"has_elevation": false,
+		"time_regex": null,
+		"elevation_regex": null,
+		"use_featureinfo_custom_template": false,
+		"featureinfo_custom_template": "",
+		"default_style": {
+			"pk": 231,
+			"name": "TEMPERATURASMINENERO2030",
+			"workspace": "geonode",
+			"sld_title": null,
+			"sld_body": "b'<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:gml=\"http://www.opengis.net/gml\" version=\"1.0.0\" xmlns:sld=\"http://www.opengis.net/sld\" xmlns:ogc=\"http://www.opengis.net/ogc\">\\n  <UserLayer>\\n    <sld:LayerFeatureConstraints>\\n      <sld:FeatureTypeConstraint/>\\n    </sld:LayerFeatureConstraints>\\n    <sld:UserStyle>\\n      <sld:Name>TEMPERATURASMINENERO2030</sld:Name>\\n      <sld:FeatureTypeStyle>\\n        <sld:Rule>\\n          <sld:RasterSymbolizer>\\n            <sld:ChannelSelection>\\n              <sld:GrayChannel>\\n                <sld:SourceChannelName>1</sld:SourceChannelName>\\n              </sld:GrayChannel>\\n            </sld:ChannelSelection>\\n            <sld:ColorMap type=\"intervals\">\\n              <sld:ColorMapEntry color=\"#132e58\" quantity=\"-49\" label=\"&lt;= -4.90\"/>\\n              <sld:ColorMapEntry color=\"#18558b\" quantity=\"-32\" label=\"-4.89 - -3.2\"/>\\n              <sld:ColorMapEntry color=\"#127ebd\" quantity=\"-1\" label=\"-3.19 - -1.00\"/>\\n              <sld:ColorMapEntry color=\"#55c5d3\" quantity=\"5\" label=\"-0.09 - 0.5\"/>\\n              <sld:ColorMapEntry color=\"#aefdf4\" quantity=\"17\" label=\"0.51 - 1.70\"/>\\n              <sld:ColorMapEntry color=\"#c7fd7e\" quantity=\"40\" label=\"1.71 - 4.00\"/>\\n              <sld:ColorMapEntry color=\"#83e611\" quantity=\"50\" label=\"4.01 - 5.00\"/>\\n              <sld:ColorMapEntry color=\"#6baa14\" quantity=\"83\" label=\"5.01 - 8.30\"/>\\n              <sld:ColorMapEntry color=\"#517317\" quantity=\"120\" label=\"8.31 - 12.00\"/>\\n              <sld:ColorMapEntry color=\"#337208\" quantity=\"187\" label=\"12.01 - 18.70\"/>\\n            </sld:ColorMap>\\n          </sld:RasterSymbolizer>\\n        </sld:Rule>\\n      </sld:FeatureTypeStyle>\\n    </sld:UserStyle>\\n  </UserLayer>\\n</StyledLayerDescriptor>\\n'",
+			"sld_version": null,
+			"sld_url": "http://geoserver:8080/geoserver/rest/workspaces/geonode/styles/TEMPERATURASMINENERO2030.sld"
+		},
+		"styles": [{
+			"pk": 231,
+			"name": "TEMPERATURASMINENERO2030",
+			"workspace": "geonode",
+			"sld_title": null,
+			"sld_body": "b'<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:gml=\"http://www.opengis.net/gml\" version=\"1.0.0\" xmlns:sld=\"http://www.opengis.net/sld\" xmlns:ogc=\"http://www.opengis.net/ogc\">\\n  <UserLayer>\\n    <sld:LayerFeatureConstraints>\\n      <sld:FeatureTypeConstraint/>\\n    </sld:LayerFeatureConstraints>\\n    <sld:UserStyle>\\n      <sld:Name>TEMPERATURASMINENERO2030</sld:Name>\\n      <sld:FeatureTypeStyle>\\n        <sld:Rule>\\n          <sld:RasterSymbolizer>\\n            <sld:ChannelSelection>\\n              <sld:GrayChannel>\\n                <sld:SourceChannelName>1</sld:SourceChannelName>\\n              </sld:GrayChannel>\\n            </sld:ChannelSelection>\\n            <sld:ColorMap type=\"intervals\">\\n              <sld:ColorMapEntry color=\"#132e58\" quantity=\"-49\" label=\"&lt;= -4.90\"/>\\n              <sld:ColorMapEntry color=\"#18558b\" quantity=\"-32\" label=\"-4.89 - -3.2\"/>\\n              <sld:ColorMapEntry color=\"#127ebd\" quantity=\"-1\" label=\"-3.19 - -1.00\"/>\\n              <sld:ColorMapEntry color=\"#55c5d3\" quantity=\"5\" label=\"-0.09 - 0.5\"/>\\n              <sld:ColorMapEntry color=\"#aefdf4\" quantity=\"17\" label=\"0.51 - 1.70\"/>\\n              <sld:ColorMapEntry color=\"#c7fd7e\" quantity=\"40\" label=\"1.71 - 4.00\"/>\\n              <sld:ColorMapEntry color=\"#83e611\" quantity=\"50\" label=\"4.01 - 5.00\"/>\\n              <sld:ColorMapEntry color=\"#6baa14\" quantity=\"83\" label=\"5.01 - 8.30\"/>\\n              <sld:ColorMapEntry color=\"#517317\" quantity=\"120\" label=\"8.31 - 12.00\"/>\\n              <sld:ColorMapEntry color=\"#337208\" quantity=\"187\" label=\"12.01 - 18.70\"/>\\n            </sld:ColorMap>\\n          </sld:RasterSymbolizer>\\n        </sld:Rule>\\n      </sld:FeatureTypeStyle>\\n    </sld:UserStyle>\\n  </UserLayer>\\n</StyledLayerDescriptor>\\n'",
+			"sld_version": null,
+			"sld_url": "http://geoserver:8080/geoserver/rest/workspaces/geonode/styles/TEMPERATURASMINENERO2030.sld"
+		}],
+		"attribute_set": [{
+			"pk": 1365,
+			"attribute": "GRAY_INDEX",
+			"description": null,
+			"attribute_label": null,
+			"attribute_type": "raster",
+			"visible": true,
+			"display_order": 1,
+			"featureinfo_type": "type_property",
+			"count": 1,
+			"min": "NA",
+			"max": "NA",
+			"average": "NA",
+			"median": "NA",
+			"stddev": "NA",
+			"sum": "NA",
+			"unique_values": "NA",
+			"last_stats_updated": "2021-01-21T18:57:31.704324Z"
+		}],
+		"resource_type": "layer",
+		"polymorphic_ctype_id": "58",
+		"owner": {
+			"pk": 1030,
+			"username": "MarceloRetamalGajardo",
+			"first_name": "",
+			"last_name": "",
+			"avatar": "https://www.gravatar.com/avatar/f5957a6dc8bc9e00f1a6f20de9da21b6/?s=240"
+		},
+		"poc": {
+			"pk": 1030,
+			"username": "MarceloRetamalGajardo",
+			"first_name": "",
+			"last_name": "",
+			"avatar": "https://www.gravatar.com/avatar/f5957a6dc8bc9e00f1a6f20de9da21b6/?s=240"
+		},
+		"metadata_author": {
+			"pk": 1030,
+			"username": "MarceloRetamalGajardo",
+			"first_name": "",
+			"last_name": "",
+			"avatar": "https://www.gravatar.com/avatar/f5957a6dc8bc9e00f1a6f20de9da21b6/?s=240"
+		},
+		"title": "TEMPERATURAS MIN ENERO 2030",
+		"abstract": "<p>No abstract provided</p>",
+		"attribution": null,
+		"doi": null,
+		"alternate": "geonode:TEMPERATURASMINENERO2030",
+		"date": "2021-01-21T18:57:00Z",
+		"date_type": "publication",
+		"temporal_extent_start": null,
+		"temporal_extent_end": null,
+		"edition": null,
+		"purpose": "",
+		"maintenance_frequency": null,
+		"constraints_other": "",
+		"language": "eng",
+		"supplemental_information": "<p>No se provee informaci&oacute;n</p>",
+		"data_quality_statement": "",
+		"bbox_polygon": {
+			"type": "Polygon",
+			"coordinates": [
+				[
+					[-73.8833242, -40.79168],
+					[-73.8833242, -39.1250132],
+					[-71.474990674, -39.1250132],
+					[-71.474990674, -40.79168],
+					[-73.8833242, -40.79168]
+				]
+			]
+		},
+		"srid": "EPSG:4326",
+		"group": null,
+		"popular_count": "2",
+		"share_count": "0",
+		"rating": "0",
+		"featured": false,
+		"is_published": true,
+		"is_approved": true,
+		"thumbnail_url": "https://master.demo.geonode.org/static/thumbs/layer-818898b8-5c1a-11eb-b604-0242ac150007-thumb.15fffae196e4.png?v=885131f3",
+		"detail_url": "/layers/TEMPERATURASMINENERO2030:geonode:TEMPERATURASMINENERO2030",
+		"created": "2021-01-21T18:57:27.717853Z",
+		"last_updated": "2021-01-21T19:19:49.765237Z",
+		"keywords": [{
+			"name": "GeoTIFF",
+			"slug": "geotiff"
+		}, {
+			"name": "TEMPERATURASMINENERO2030",
+			"slug": "temperaturasminenero2030"
+		}, {
+			"name": "WCS",
+			"slug": "wcs"
+		}],
+		"regions": [{
+			"code": "GLO",
+			"name": "Global"
+		}],
+		"category": null,
+		"restriction_code_type": null,
+		"license": {
+			"identifier": "not_specified"
+		},
+		"spatial_representation_type": null
+	}]
+}

--- a/test/_mock_geonode_data/map_list_filtered_response1.json
+++ b/test/_mock_geonode_data/map_list_filtered_response1.json
@@ -1,0 +1,93 @@
+{
+	"links": {
+		"next": "https://master.demo.geonode.org/api/v2/maps?format=json&page=2&page_size=2",
+		"previous": null
+	},
+	"total": 8,
+	"page": 1,
+	"page_size": 2,
+	"maps": [{
+		"pk": "70",
+		"uuid": "c5448d9e-5807-11eb-867c-0242ac150007",
+		"zoom": 6,
+		"projection": "EPSG:3857",
+		"center_x": 108.298542308941,
+		"center_y": 3.97606421856882,
+		"urlsuffix": "",
+		"featuredurl": "",
+		"resource_type": "map",
+		"polymorphic_ctype_id": "62",
+		"owner": {
+			"pk": 1011,
+			"username": "ikaatika",
+			"first_name": "",
+			"last_name": "",
+			"avatar": "https://www.gravatar.com/avatar/8c3de20bf80b247d329f77917914cd93/?s=240"
+		},
+		"poc": {
+			"pk": 1011,
+			"username": "ikaatika",
+			"first_name": "",
+			"last_name": "",
+			"avatar": "https://www.gravatar.com/avatar/8c3de20bf80b247d329f77917914cd93/?s=240"
+		},
+		"metadata_author": {
+			"pk": 1011,
+			"username": "ikaatika",
+			"first_name": "",
+			"last_name": "",
+			"avatar": "https://www.gravatar.com/avatar/8c3de20bf80b247d329f77917914cd93/?s=240"
+		},
+		"title": "AIRPORT",
+		"abstract": "test",
+		"attribution": null,
+		"doi": null,
+		"alternate": null,
+		"date": "2021-01-16T14:33:15.904178Z",
+		"date_type": "publication",
+		"temporal_extent_start": null,
+		"temporal_extent_end": null,
+		"edition": null,
+		"purpose": null,
+		"maintenance_frequency": null,
+		"constraints_other": null,
+		"language": "eng",
+		"supplemental_information": "No information provided",
+		"data_quality_statement": null,
+		"bbox_polygon": {
+			"type": "Polygon",
+			"coordinates": [
+				[
+					[-10.985355262641962, -7.690393965001899],
+					[-10.985355262641962, 7.690465400187064],
+					[10.987300987358042, 7.690465400187064],
+					[10.987300987358042, -7.690393965001899],
+					[-10.985355262641962, -7.690393965001899]
+				]
+			]
+		},
+		"srid": "EPSG:4326",
+		"group": null,
+		"popular_count": "5",
+		"share_count": "0",
+		"rating": "0",
+		"featured": false,
+		"is_published": true,
+		"is_approved": true,
+		"thumbnail_url": "https://master.demo.geonode.org/static/thumbs/map-c5448d9e-5807-11eb-867c-0242ac150007-thumb.0166afa7cc34.png?v=1dbc3c48",
+		"detail_url": "/maps/70",
+		"created": "2021-01-16T14:33:15.946319Z",
+		"last_updated": "2021-01-16T14:33:47.051858Z",
+		"keywords": [],
+		"regions": [{
+			"code": "GLO",
+			"name": "Global"
+		}],
+		"category": null,
+		"restriction_code_type": null,
+		"license": {
+			"identifier": "not_specified"
+		},
+		"spatial_representation_type": null
+	}]
+}

--- a/test/test_apiclient.py
+++ b/test/test_apiclient.py
@@ -47,7 +47,7 @@ def test_layer_list_filtering(qtbot, qgis_application, mock_geonode_server, page
     client = api_client.GeonodeClient(base_url="http://localhost:9000")
     client.layer_list_received.connect(app.collect_response)
     with qtbot.waitSignal(client.layer_list_received, timeout=SIGNAL_TIMEOUT * 1000):
-        client.get_layers(page=page, filters={"filter{name}": "TEMPERATURASMINENERO2030"})
+        client.get_layers(page=page, title="TEMPERATURASMINENERO2030")
     layers, total_results, page_number, page_size = app.received_response
 
     print(f"layer ids: {[la.pk for la in layers]}")
@@ -98,7 +98,7 @@ def test_map_list_filtering(qtbot, qgis_application, mock_geonode_server, page):
     client = api_client.GeonodeClient(base_url="http://localhost:9000")
     client.map_list_received.connect(app.collect_response)
     with qtbot.waitSignal(client.map_list_received, timeout=SIGNAL_TIMEOUT * 1000):
-        client.get_maps(page=page, filters={"filter{title}": "AIRPORT"})
+        client.get_maps(page=page, title="AIRPORT")
     maps, total_results, page_number, page_size = app.received_response
 
     assert page_size == 2

--- a/test/test_apiclient.py
+++ b/test/test_apiclient.py
@@ -41,6 +41,23 @@ def test_layer_list(qtbot, qgis_application, mock_geonode_server, page):
     assert page_size == 2
 
 
+@pytest.mark.parametrize("page", [pytest.param(None, id="no explicit page")])
+def test_layer_list_filtering(qtbot, qgis_application, mock_geonode_server, page):
+    app = ResponseCollector()
+    client = api_client.GeonodeClient(base_url="http://localhost:9000")
+    client.layer_list_received.connect(app.collect_response)
+    with qtbot.waitSignal(client.layer_list_received, timeout=SIGNAL_TIMEOUT * 1000):
+        client.get_layers(page=page, filters={"filter{name}": "TEMPERATURASMINENERO2030"})
+    layers, total_results, page_number, page_size = app.received_response
+
+    print(f"layer ids: {[la.pk for la in layers]}")
+
+    layers_size = len(layers)
+
+    assert layers_size == 1
+    assert layers[0].name == "TEMPERATURASMINENERO2030"
+
+
 @pytest.mark.parametrize("id_", [pytest.param(184)])
 def test_layer_details(qtbot, qgis_application, mock_geonode_server, id_):
     app = ResponseCollector()
@@ -73,3 +90,17 @@ def test_map_list(qtbot, qgis_application, mock_geonode_server, page):
     maps, total_results, page_number, page_size = app.received_response
     assert page_size == 2
     assert maps[0].pk == 43
+
+
+@pytest.mark.parametrize("page", [pytest.param(None, id="no explicit page")])
+def test_map_list_filtering(qtbot, qgis_application, mock_geonode_server, page):
+    app = ResponseCollector()
+    client = api_client.GeonodeClient(base_url="http://localhost:9000")
+    client.map_list_received.connect(app.collect_response)
+    with qtbot.waitSignal(client.map_list_received, timeout=SIGNAL_TIMEOUT * 1000):
+        client.get_maps(page=page, filters={"filter{title}": "AIRPORT"})
+    maps, total_results, page_number, page_size = app.received_response
+
+    assert page_size == 2
+    assert len(maps) == 1
+    assert maps[0].pk == 70


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/29

Adds support in the API client for using search filters on the GeoNode V2 API. The added tests are only covering the equality operation for filtering.

The logic for creating filtering query strings is left for API client users(GUI).