### PR TITLE
Support for search filtering in the GUI

### DIFF
--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -226,6 +226,10 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
                 client.get_layers(
                     page=self.current_page
                 )
+        else:
+            client.get_layers(
+                page=self.current_page
+            )
 
     def show_search_error(self, error):
         self.message_bar.clearWidgets()

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -109,7 +109,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         metadata.setLanguage(geonode_resource.language)
         metadata.setKeywords({"layer": geonode_resource.keywords})
         if geonode_resource.category:
-            metadata.setCategories([c["identifier"] for c in geonode_resource.category])
+            metadata.setCategories([geonode_resource.category['identifier']])
         if geonode_resource.license:
             metadata.setLicenses([geonode_resource.license])
         if geonode_resource.constraints:

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -109,7 +109,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         metadata.setLanguage(geonode_resource.language)
         metadata.setKeywords({"layer": geonode_resource.keywords})
         if geonode_resource.category:
-            metadata.setCategories([geonode_resource.category['identifier']])
+            metadata.setCategories([geonode_resource.category])
         if geonode_resource.license:
             metadata.setLicenses([geonode_resource.license])
         if geonode_resource.constraints:

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -111,7 +111,7 @@
       <string>Search Items</string>
      </property>
      <property name="checkable">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="checked">
       <bool>false</bool>
@@ -122,17 +122,54 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="5" column="2">
-         <widget class="QgsDateTimeEdit" name="end_date_time">
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_6">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>End</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Keywords</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Resource type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="keywords_cmb">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QToolButton" name="keyword_tool_btn">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
          <widget class="QLineEdit" name="free_text_edit">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="toolTip">
            <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
@@ -142,133 +179,81 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QLabel" name="label_5">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Resource type</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLabel" name="label_6">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>End</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="label_3">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Keywords</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QComboBox" name="keywords_cmb">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QgsDateTimeEdit" name="start_date_time">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QComboBox" name="category_cmb">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="label_2">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Topic Category</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="label">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Free Text</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_4">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="text">
            <string>Start</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="6" column="1">
+         <widget class="QgsDateTimeEdit" name="end_date_time">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="abstract_edit">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
          <widget class="QComboBox" name="resource_type_cmb">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="category_cmb">
+          <property name="enabled">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QCheckBox" name="free_text_box">
-          <property name="text">
-           <string/>
+         <widget class="QLabel" name="label">
+          <property name="enabled">
+           <bool>true</bool>
           </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="keywords_box">
           <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="category_box">
-          <property name="text">
-           <string/>
+           <string>Free Text</string>
           </property>
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QCheckBox" name="resource_type_box">
+         <widget class="QLabel" name="label_2">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="text">
-           <string/>
+           <string>Topic Category</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="start_time_box">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="text">
-           <string/>
+           <string>Abstract</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QCheckBox" name="end_time_box">
-          <property name="text">
-           <string/>
+        <item row="5" column="1">
+         <widget class="QgsDateTimeEdit" name="start_date_time">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="allowNull">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -283,7 +268,7 @@
          <string>Spatial Extent</string>
         </property>
         <property name="checkable">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="checked">
          <bool>false</bool>
@@ -408,7 +393,7 @@
         <x>0</x>
         <y>0</y>
         <width>770</width>
-        <height>92</height>
+        <height>68</height>
        </rect>
       </property>
      </widget>
@@ -482,214 +467,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>104</x>
-     <y>137</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>71</x>
-     <y>162</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>free_text_edit</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>433</x>
-     <y>131</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>443</x>
-     <y>160</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>keywords_cmb</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>201</x>
-     <y>125</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>172</x>
-     <y>189</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_3</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>295</x>
-     <y>126</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>100</x>
-     <y>202</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>category_cmb</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>333</x>
-     <y>124</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>183</x>
-     <y>224</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>366</x>
-     <y>127</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>112</x>
-     <y>228</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_5</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>285</x>
-     <y>122</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>96</x>
-     <y>255</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_4</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>243</x>
-     <y>125</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>64</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resource_type_cmb</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>160</x>
-     <y>130</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>260</x>
-     <y>263</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>start_date_time</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>493</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>527</x>
-     <y>286</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>end_date_time</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>589</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>563</x>
-     <y>316</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_6</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>637</x>
-     <y>131</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>41</x>
-     <y>322</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>search_group_box</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mGroupBox_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>681</x>
-     <y>128</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>660</x>
-     <y>347</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>790</width>
-    <height>661</height>
+    <height>670</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -119,147 +119,196 @@
      <property name="collapsed">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_6">
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="title_le">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
+        </property>
+        <property name="whatsThis">
+         <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Abstract</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="abstract_le">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Keywords</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QComboBox" name="keyword_cmb">
           <property name="enabled">
            <bool>true</bool>
           </property>
-          <property name="text">
-           <string>End</string>
-          </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Keywords</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Resource type</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="keywords_cmb">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
+        <item>
          <widget class="QToolButton" name="keyword_tool_btn">
           <property name="text">
            <string>...</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="free_text_edit">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="toolTip">
-           <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-          </property>
-          <property name="whatsThis">
-           <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
+       </layout>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Topic Category</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="category_cmb">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Resource types</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="vector_chb">
           <property name="text">
-           <string>Start</string>
+           <string>Vector</string>
           </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QgsDateTimeEdit" name="end_date_time">
-          <property name="enabled">
+          <property name="checked">
            <bool>true</bool>
           </property>
+          <attribute name="buttonGroup">
+           <string notr="true">resource_types_btngrp</string>
+          </attribute>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="abstract_edit">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="resource_type_cmb">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="category_cmb">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
+        <item>
+         <widget class="QCheckBox" name="raster_chb">
           <property name="text">
-           <string>Free Text</string>
+           <string>Raster</string>
           </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="enabled">
+          <property name="checked">
            <bool>true</bool>
           </property>
+          <attribute name="buttonGroup">
+           <string notr="true">resource_types_btngrp</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="map_chb">
           <property name="text">
-           <string>Topic Category</string>
+           <string>Map</string>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">resource_types_btngrp</string>
+          </attribute>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="enabled">
-           <bool>true</bool>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="text">
-           <string>Abstract</string>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
           </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QgsDateTimeEdit" name="start_date_time">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="allowNull">
-           <bool>true</bool>
-          </property>
-         </widget>
+         </spacer>
         </item>
        </layout>
       </item>
-      <item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Start</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QgsDateTimeEdit" name="start_dte">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="allowNull">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>End</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QgsDateTimeEdit" name="end_dte">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
        <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
         <property name="enabled">
          <bool>false</bool>
@@ -393,7 +442,7 @@
         <x>0</x>
         <y>0</y>
         <width>770</width>
-        <height>68</height>
+        <height>90</height>
        </rect>
       </property>
      </widget>
@@ -468,4 +517,11 @@
  </customwidgets>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="resource_types_btngrp">
+   <property name="exclusive">
+    <bool>false</bool>
+   </property>
+  </buttongroup>
+ </buttongroups>
 </ui>

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -103,28 +103,34 @@
     </widget>
    </item>
    <item>
-    <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+    <widget class="QgsCollapsibleGroupBox" name="search_group_box">
      <property name="enabled">
       <bool>true</bool>
      </property>
      <property name="title">
       <string>Search Items</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="5" column="2">
+         <widget class="QgsDateTimeEdit" name="end_date_time">
           <property name="enabled">
            <bool>false</bool>
           </property>
-          <property name="text">
-           <string>Free Text</string>
-          </property>
          </widget>
         </item>
-        <item>
-         <widget class="QLineEdit" name="lineFilter_2">
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="free_text_edit">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -136,53 +142,7 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Keywords</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="comboBox_2">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Topic Category</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="comboBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
+        <item row="3" column="1">
          <widget class="QLabel" name="label_5">
           <property name="enabled">
            <bool>false</bool>
@@ -192,39 +152,7 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QComboBox" name="comboBox_4">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Start</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="comboBox_3">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
+        <item row="5" column="1">
          <widget class="QLabel" name="label_6">
           <property name="enabled">
            <bool>false</bool>
@@ -234,17 +162,117 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QComboBox" name="comboBox_5">
+        <item row="1" column="1">
+         <widget class="QLabel" name="label_3">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Keywords</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QComboBox" name="keywords_cmb">
           <property name="enabled">
            <bool>false</bool>
           </property>
          </widget>
         </item>
+        <item row="4" column="2">
+         <widget class="QgsDateTimeEdit" name="start_date_time">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QComboBox" name="category_cmb">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="label_2">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Topic Category</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Free Text</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLabel" name="label_4">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Start</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QComboBox" name="resource_type_cmb">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="free_text_box">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="keywords_box">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="category_box">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="resource_type_box">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="start_time_box">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="end_time_box">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10"/>
       </item>
       <item>
        <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
@@ -253,6 +281,15 @@
         </property>
         <property name="title">
          <string>Spatial Extent</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="collapsed">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -371,7 +408,7 @@
         <x>0</x>
         <y>0</y>
         <width>770</width>
-        <height>74</height>
+        <height>92</height>
        </rect>
       </property>
      </widget>
@@ -427,7 +464,7 @@
   </layout>
   <zorder>scroll_area</zorder>
   <zorder>groupBox</zorder>
-  <zorder>mGroupBox</zorder>
+  <zorder>search_group_box</zorder>
   <zorder>search_btn</zorder>
   <zorder>buttonBox</zorder>
  </widget>
@@ -438,7 +475,221 @@
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>104</x>
+     <y>137</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>71</x>
+     <y>162</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>free_text_edit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>433</x>
+     <y>131</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>443</x>
+     <y>160</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>keywords_cmb</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>201</x>
+     <y>125</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>172</x>
+     <y>189</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_3</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>295</x>
+     <y>126</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>100</x>
+     <y>202</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>category_cmb</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>333</x>
+     <y>124</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>183</x>
+     <y>224</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_2</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>366</x>
+     <y>127</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>112</x>
+     <y>228</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_5</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>285</x>
+     <y>122</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>96</x>
+     <y>255</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_4</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>243</x>
+     <y>125</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>64</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>resource_type_cmb</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>160</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>260</x>
+     <y>263</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>start_date_time</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>493</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>527</x>
+     <y>286</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>end_date_time</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>589</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>563</x>
+     <y>316</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_6</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>637</x>
+     <y>131</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>41</x>
+     <y>322</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>search_group_box</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mGroupBox_2</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>681</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>660</x>
+     <y>347</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -1,8 +1,31 @@
+import enum
 import typing
 
 from PyQt5.QtCore import QCoreApplication
 
 from qgis.core import QgsMessageLog, Qgis
+
+
+class IsoTopicCategory(enum.Enum):
+    FARMING = "Farming"
+    CLIMATOLOGY_METEOROLOGY_ATMOSPHERE = "Climatology Meteorology Atmosphere"
+    LOCATION = "Location"
+    INTELLIGENCE_MILITARY = "Intelligence Military"
+    TRANSPORTATION = "Transportation"
+    STRUCTURE = "Structure"
+    BOUNDARIES = "Boundaries"
+    INLAND_WATERS = "Inland Waters"
+    PLANNING_CADASTRE = "Planning Cadastre"
+    GEOSCIENTIFIC_INFORMATION = "Geoscientific Information"
+    ELEVATION = "Elevation"
+    HEALTH = "Health"
+    BIOTA = "Biota"
+    OCEANS = "Oceans"
+    ENVIRONMENT = "Environment"
+    UTILITIES_COMMUNICATION = "Utilities Communication"
+    ECONOMY = "Economy"
+    SOCIETY = "Society"
+    IMAGERY_BASE_MAPS_EARTH_COVER = "Imagery Base Maps Earth Cover"
 
 
 def log(message: str, name: str = "qgis_geonode", debug: bool = True):


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/80

Adds search filtering via GUI, now it searches using all the field items except start, end and spatial extent items.
The current search filtering doesn't support filtering with more than one field, The free text is treated as a title when filtering, abstract will be included once a better way of filtering two different fields has been
devised.

The search filter items UI is updated to included checkboxes that will allow user to later have options about which items they want to include in filtering resources.

This PR also adds fetching of all keywords in the GeoNode instance using endpoint '/h_keywords_api'.

Screenshot
![search_filtering](https://user-images.githubusercontent.com/2663775/107441115-bcd62b80-6b45-11eb-9c4b-bb2e7ef2978d.gif)
