### PR TITLE
Show layer thumbnails on search results page

### DIFF
--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -31,6 +31,12 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="description_la">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
            <string>Description</string>
           </property>
@@ -40,12 +46,18 @@
          </widget>
         </item>
         <item>
-         <widget class="QFrame" name="frame">
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
+         <widget class="QLabel" name="thumbnail_la">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
           </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
+          <property name="frameShape">
+           <enum>QFrame::Box</enum>
+          </property>
+          <property name="text">
+           <string>Thumbnail</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This PR implements loading a GeoNode resource's thumbnail and showing it the QGIS search results section, as depicted in the screenshot below:

![prn-qgis-geonode-layer-thumbnail](https://user-images.githubusercontent.com/732010/107772878-ba85f400-6d34-11eb-87a4-de26dcb449d2.png)

fixes #65 