### PR TITLE
Make resource title bigger and add resource type

### DIFF
--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -41,7 +41,8 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
     ):
         super().__init__(parent)
         self.setupUi(self)
-        self.name_la.setText(geonode_resource.title)
+        self.name_la.setText(f"<h3>{geonode_resource.title}</h3>")
+        self.resource_type_la.setText(geonode_resource.resource_type.value)
         self.description_la.setText(geonode_resource.abstract)
         self.geonode_resource = geonode_resource
         self.message_bar = message_bar
@@ -196,4 +197,4 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
             thumbnail.loadFromData(contents)
             self.thumbnail_la.setPixmap(thumbnail)
         else:
-            log(f"Error retrieving thumbnail for {self.geonode_resource.name}")
+            log(f"Error retrieving thumbnail for {self.geonode_resource.title}")

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -14,18 +14,62 @@
    <string>Resource</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="QWidget" name="resource" native="true">
+    <widget class="QFrame" name="resource">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QLabel" name="name_la">
-        <property name="text">
-         <string>Resource</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="name_la">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="text">
+           <string>Resource title</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="resource_type_la">
+          <property name="text">
+           <string>Resource type</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
@@ -39,6 +83,9 @@
           </property>
           <property name="text">
            <string>Description</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -117,19 +164,6 @@
            <string>File Download</string>
           </property>
          </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item>
          <widget class="QPushButton" name="browser_btn">


### PR DESCRIPTION
This PR adds some small improvements to the resource search page, namely:

- resource title is now bigger
- abstract is aligned to top
- resource type is now shown

![prn-qgis-geonode-search-results](https://user-images.githubusercontent.com/732010/107776810-f7081e80-6d39-11eb-9c5d-a7b75482465e.png)
