### PR TITLE
98 geonode csw interface uses session auth

### DIFF
--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -308,17 +308,17 @@ def _get_published_date(payload: typing.Dict) -> typing.Optional[dt.datetime]:
 
 
 def _get_wms_uri(
-        base_url: str,
-        payload: typing.Dict,
-        auth_config: typing.Optional[str] = None,
+    base_url: str,
+    payload: typing.Dict,
+    auth_config: typing.Optional[str] = None,
 ) -> str:
     params = {
         "url": f"{base_url}/geoserver/ows",
         "format": "image/png",
         "layers": f"{payload['workspace']}:{payload['name']}",
-        "crs": payload['srid'],
+        "crs": payload["srid"],
         "styles": "",
-        "version": "auto"
+        "version": "auto",
     }
     if auth_config is not None:
         params["authcfg"] = auth_config
@@ -326,13 +326,13 @@ def _get_wms_uri(
 
 
 def _get_wcs_uri(
-        base_url: str,
-        payload: typing.Dict,
-        auth_config: typing.Optional[str] = None,
+    base_url: str,
+    payload: typing.Dict,
+    auth_config: typing.Optional[str] = None,
 ) -> str:
     params = {
         "identifier": f"{payload['workspace']}:{payload['name']}",
-        "url": f"{base_url}/geoserver/ows"
+        "url": f"{base_url}/geoserver/ows",
     }
     if auth_config is not None:
         params["authcfg"] = auth_config
@@ -340,9 +340,7 @@ def _get_wcs_uri(
 
 
 def _get_wfs_uri(
-        base_url: str,
-        payload: typing.Dict,
-        auth_config: typing.Optional[str] = None
+    base_url: str, payload: typing.Dict, auth_config: typing.Optional[str] = None
 ) -> str:
     params = {
         "url": f"{base_url}/geoserver/ows",

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -204,96 +204,6 @@ class GeonodeCswClient(BaseGeonodeClient):
             title, abstract, keyword, topic_category, layer_types, page, page_size
         )
 
-    # def _login(
-    #         self,
-    #         post_login_handler: typing.Optional[typing.Callable] = None,
-    #         post_login_handler_kwargs: typing.Optional[typing.Dict] = None
-    # ):
-    #     """perform asynchronous login
-    #
-    #     This means making two HTTP requests:
-    #     - first a GET request to obtain the CSRF token
-    #     - then a POST request to actually log in
-    #
-    #     """
-    #     login_request = QtNetwork.QNetworkRequest(
-    #         QtCore.QUrl(f"{self.base_url}/account/login/"))
-    #     self._async_get_csrf_token(
-    #         login_request, self._finalize_login,
-    #         reply_handler_kwargs={
-    #             "post_login_handler": post_login_handler,
-    #             "post_login_handler_kwargs": post_login_handler_kwargs,
-    #         }
-    #     )
-
-    # def _async_get_csrf_token(
-    #         self,
-    #         request: QtNetwork.QNetworkRequest,
-    #         reply_handler: typing.Callable,
-    #         reply_handler_kwargs: typing.Optional[typing.Dict] = None
-    # ):
-    #
-    #     network_manager = QgsNetworkAccessManager.instance()
-    #     # NOTE: we can't use a blocking request here because it would run on another
-    #     # thread and thus would use a different network_manager. This network manager
-    #     # would store the cookies sent in the reply and we would not be able to access
-    #     # them - therefore we use a normal async GET request
-    #     reply = network_manager.get(request, auth_cfg=None)
-    #     handler_kwargs = (
-    #         reply_handler_kwargs if reply_handler_kwargs is not None else {})
-    #     reply.finished.connect(partial(reply_handler, reply, **handler_kwargs))
-
-    # def _finalize_login(
-    #         self,
-    #         reply: QtNetwork.QNetworkReply,
-    #         post_login_handler: typing.Optional[typing.Callable] = None,
-    #         post_login_handler_kwargs: typing.Optional[typing.Dict] = None,
-    # ):
-    #     if reply.error() == QtNetwork.QNetworkReply.NoError:
-    #         network_manager = QgsNetworkAccessManager.instance()
-    #         cookie_jar = network_manager.cookieJar()
-    #         url = reply.request().url()
-    #         csrftoken_cookies = [
-    #             c for c in cookie_jar.cookiesForUrl(url) if c.name() == "csrftoken"]
-    #         if len(csrftoken_cookies) > 0:
-    #             csrftoken_cookie = csrftoken_cookies[0]
-    #             token = csrftoken_cookie.value()
-    #             request = QtNetwork.QNetworkRequest(url)
-    #             request.setHeader(
-    #                 QtNetwork.QNetworkRequest.ContentTypeHeader,
-    #                 "application/x-www-form-urlencoded"
-    #             )
-    #             request.setRawHeader("Referer", url.toEncoded())
-    #             data = QtCore.QUrlQuery()
-    #             data.addQueryItem("csrfmiddlewaretoken", token)
-    #             basic_auth_cfg = None  # FIXME: set this
-    #             login_reply = network_manager.post(
-    #                 request,
-    #                 data.toString(QtCore.QUrl.FullyEncoded),
-    #                 auth_cfg=basic_auth_cfg
-    #             )
-    #             if post_login_handler is not None:
-    #                 handler = partial(post_login_handler, **post_login_handler_kwargs)
-    #                 login_reply.finished.connect(handler)
-    #     else:
-    #         status_code = reply.attribute(
-    #             QtNetwork.QNetworkRequest.HttpStatusCodeAttribute)
-    #         log(f"Could not finalize login: {status_code}")
-
-    # def _get_layers_after_login(
-    #         self,
-    #         reply: QtNetwork.QNetworkReply,
-    #         title: typing.Optional[str] = None,
-    #         abstract: typing.Optional[str] = None,
-    #         keyword: typing.Optional[str] = None,
-    #         topic_category: typing.Optional[str] = None,
-    #         layer_types: typing.Optional[
-    #             typing.List[models.GeonodeResourceType]] = None,
-    #         page: typing.Optional[int] = 1,
-    #         page_size: typing.Optional[int] = 10,
-    # ):
-    #     pass
-
     def deserialize_response_contents(self, contents: QtCore.QByteArray) -> ET.Element:
         decoded_contents: str = contents.data().decode()
         log(f"decoded_contents: {decoded_contents}")
@@ -356,6 +266,8 @@ def get_geonode_resource(
         constraints="",  # FIXME: get constraints from record
         owner="",  # FIXME: extract owner
         metadata_author="",  # FIXME: extract metadata author
+        default_style=None,
+        styles=[],
         **common_fields,
     )
 

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -272,7 +272,7 @@ class GeonodeCswClient(BaseGeonodeClient):
                 payload.find(f"{{{Csw202Namespace.GMD.value}}}MD_Metadata"),
                 self.base_url,
                 self.auth_config,
-                default_style=brief_style
+                default_style=brief_style,
             )
             self.layer_detail_received.emit(layer)
 
@@ -286,9 +286,7 @@ class GeonodeCswClient(BaseGeonodeClient):
             )
         )
         request = urllib.request.Request(
-            layer_detail_url,
-            headers={"Referer": self.base_url},
-            method="GET"
+            layer_detail_url, headers={"Referer": self.base_url}, method="GET"
         )
         layer_detail_response = self.request_opener.open(request)
         if layer_detail_response.status != 200:
@@ -310,7 +308,7 @@ class GeonodeCswClient(BaseGeonodeClient):
         request = urllib.request.Request(
             f"{self.base_url}{style_uri}",
             headers={"Referer": self.base_url},
-            method="GET"
+            method="GET",
         )
         style_detail_response = self.request_opener.open(request)
         if style_detail_response.status != 200:
@@ -652,7 +650,7 @@ def _get_wms_uri(
         "layers": layer_name,
         "crs": f"EPSG:{crs.postgisSrid()}",
         "styles": "",
-        "version": "auto"
+        "version": "auto",
     }
     if auth_config is not None:
         params["authcfg"] = auth_config
@@ -666,7 +664,7 @@ def _get_wcs_uri(
 ) -> str:
     params = {
         "identifier": layer_name,
-        "url": _find_protocol_linkage(record, "ogc:wcs")
+        "url": _find_protocol_linkage(record, "ogc:wcs"),
     }
     if auth_config is not None:
         params["authcfg"] = auth_config

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -52,18 +52,19 @@ class GeonodeCswClient(BaseGeonodeClient):
     password: typing.Optional[str]
 
     def __init__(
-            self,
-            *args,
-            username: typing.Optional[str] = None,
-            password: typing.Optional[str] = None,
-            **kwargs
+        self,
+        *args,
+        username: typing.Optional[str] = None,
+        password: typing.Optional[str] = None,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.username = username or "ricardo"
         self.password = password or "0seTY7nr4CAu"
         self.python_cookie_jar = http.cookiejar.CookieJar()
         self.request_opener = urllib.request.build_opener(
-            urllib.request.HTTPCookieProcessor(self.python_cookie_jar))
+            urllib.request.HTTPCookieProcessor(self.python_cookie_jar)
+        )
 
     @property
     def catalogue_url(self):
@@ -188,8 +189,9 @@ class GeonodeCswClient(BaseGeonodeClient):
             if logged_in:
                 session_cookie = QtNetwork.QNetworkCookie(
                     name="sessionid".encode("utf-8"),
-                    value=self.python_cookie_jar._cookies[
-                        self.host]["/"]["sessionid"].value.encode("utf-8")
+                    value=self.python_cookie_jar._cookies[self.host]["/"][
+                        "sessionid"
+                    ].value.encode("utf-8"),
                 )
                 session_cookie.setDomain(self.host)
                 session_cookie.setPath("/")
@@ -199,7 +201,8 @@ class GeonodeCswClient(BaseGeonodeClient):
             else:
                 raise RuntimeError("Unable to login")
         super().get_layers(
-            title, abstract, keyword, topic_category, layer_types, page, page_size)
+            title, abstract, keyword, topic_category, layer_types, page, page_size
+        )
 
     # def _login(
     #         self,

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -277,9 +277,11 @@ class GeonodeCswClient(BaseGeonodeClient):
             self.layer_detail_received.emit(layer)
 
     def blocking_get_layer_detail(self, layer_title: str) -> typing.Dict:
-        layer_detail_url = "?".join((
-            f"{self.base_url}/api/layers/",
-            urllib.parse.urlencode({"name": layer_title}))
+        layer_detail_url = "?".join(
+            (
+                f"{self.base_url}/api/layers/",
+                urllib.parse.urlencode({"title": layer_title}),
+            )
         )
         layer_detail_response = self.request_opener.open(layer_detail_url)
         if layer_detail_response.status != 200:
@@ -289,7 +291,8 @@ class GeonodeCswClient(BaseGeonodeClient):
             layer_detail = payload["objects"][0]
         except KeyError:
             raise IOError(
-                f"Received unexpected API response for layer {layer_title!r} detail")
+                f"Received unexpected API response for layer {layer_title!r} detail"
+            )
         else:
             return layer_detail
 
@@ -298,15 +301,16 @@ class GeonodeCswClient(BaseGeonodeClient):
         if style_detail_response.status != 200:
             raise IOError(f"Could not retrieve style {style_uri!r} detail")
         style_detail = json.load(style_detail_response)
-        sld_url = urllib.parse.urlparse(style_detail["sld_url"]).path
         return models.BriefGeonodeStyle(
             name=style_detail["name"],
-            sld_url=sld_url
+            sld_url=(
+                f"{self.base_url}{urllib.parse.urlparse(style_detail['sld_url']).path}"
+            ),
         )
 
 
 def get_brief_geonode_resource(
-        record: ET.Element, geonode_base_url: str, auth_config: str
+    record: ET.Element, geonode_base_url: str, auth_config: str
 ) -> models.BriefGeonodeResource:
     return models.BriefGeonodeResource(
         **_get_common_model_fields(record, geonode_base_url, auth_config)
@@ -314,10 +318,10 @@ def get_brief_geonode_resource(
 
 
 def get_geonode_resource(
-        record: ET.Element,
-        geonode_base_url: str,
-        auth_config: str,
-        default_style: models.BriefGeonodeStyle
+    record: ET.Element,
+    geonode_base_url: str,
+    auth_config: str,
+    default_style: models.BriefGeonodeStyle,
 ) -> models.GeonodeResource:
     common_fields = _get_common_model_fields(record, geonode_base_url, auth_config)
 

--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -52,8 +52,8 @@ class ApiVersionSpecificSettings:
 class GeonodeCswSpecificConnectionSettings(ApiVersionSpecificSettings):
     username: typing.Optional[str] = None
     password: typing.Optional[str] = None
-    _username_widget_name: str = "username_le"
-    _password_widget_name: str = "password_le"
+    _username_widget_name: str = "csw_api_username_le"
+    _password_widget_name: str = "csw_api_password_le"
 
     @classmethod
     def from_qgs_settings(cls, settings: QgsSettings):
@@ -72,7 +72,7 @@ class GeonodeCswSpecificConnectionSettings(ApiVersionSpecificSettings):
         )
 
     @classmethod
-    def get_widgets(cls) -> QtWidgets.QLayout:
+    def get_widgets(cls, group_box_name: str, title: str) -> QtWidgets.QGroupBox:
         username_le = QtWidgets.QLineEdit()
         username_le.setObjectName(cls._username_widget_name)
         password_le = QtWidgets.QLineEdit()
@@ -80,7 +80,10 @@ class GeonodeCswSpecificConnectionSettings(ApiVersionSpecificSettings):
         layout = QtWidgets.QFormLayout()
         layout.addRow(QtWidgets.QLabel("Username"), username_le)
         layout.addRow(QtWidgets.QLabel("Password"), password_le)
-        return layout
+        box = QtWidgets.QGroupBox(title=title)
+        box.setObjectName(group_box_name)
+        box.setLayout(layout)
+        return box
 
     def fill_widgets(self, ancestor: QtWidgets.QWidget):
         if self.username is not None:

--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -9,6 +9,7 @@ from qgis.PyQt import (
     QtWidgets,
 )
 from qgis.core import QgsSettings
+from qgis.gui import QgsPasswordLineEdit
 
 from .apiclient import GeonodeApiVersion
 
@@ -75,7 +76,7 @@ class GeonodeCswSpecificConnectionSettings(ApiVersionSpecificSettings):
     def get_widgets(cls, group_box_name: str, title: str) -> QtWidgets.QGroupBox:
         username_le = QtWidgets.QLineEdit()
         username_le.setObjectName(cls._username_widget_name)
-        password_le = QtWidgets.QLineEdit()
+        password_le = QgsPasswordLineEdit()
         password_le.setObjectName(cls._password_widget_name)
         layout = QtWidgets.QFormLayout()
         layout.addRow(QtWidgets.QLabel("Username"), username_le)

--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -65,13 +65,10 @@ class GeonodeCswSpecificConnectionSettings(ApiVersionSpecificSettings):
 
     @classmethod
     def from_widgets(cls, ancestor: QtWidgets.QWidget):
-        username_le = ancestor.findChild(
-            QtWidgets.QLineEdit, cls._username_widget_name)
-        password_le = ancestor.findChild(
-            QtWidgets.QLineEdit, cls._password_widget_name)
+        username_le = ancestor.findChild(QtWidgets.QLineEdit, cls._username_widget_name)
+        password_le = ancestor.findChild(QtWidgets.QLineEdit, cls._password_widget_name)
         return cls(
-            username=username_le.text() or None,
-            password=password_le.text() or None
+            username=username_le.text() or None, password=password_le.text() or None
         )
 
     @classmethod
@@ -88,22 +85,22 @@ class GeonodeCswSpecificConnectionSettings(ApiVersionSpecificSettings):
     def fill_widgets(self, ancestor: QtWidgets.QWidget):
         if self.username is not None:
             username_le = ancestor.findChild(
-                QtWidgets.QLineEdit, self._username_widget_name)
+                QtWidgets.QLineEdit, self._username_widget_name
+            )
             username_le.setText(self.username)
         if self.password is not None:
             password_le = ancestor.findChild(
-                QtWidgets.QLineEdit, self._password_widget_name)
+                QtWidgets.QLineEdit, self._password_widget_name
+            )
             password_le.setText(self.password)
 
     def to_qgs_settings(self) -> typing.Dict:
-        return {
-            "username": self.username,
-            "password": self.password
-        }
+        return {"username": self.username, "password": self.password}
 
 
 def get_api_version_settings_handler(
-        api_version: GeonodeApiVersion) -> typing.Optional[typing.Type]:
+    api_version: GeonodeApiVersion,
+) -> typing.Optional[typing.Type]:
     return {
         GeonodeApiVersion.OGC_CSW: GeonodeCswSpecificConnectionSettings,
     }.get(api_version)
@@ -119,7 +116,8 @@ class ConnectionSettings:
     api_version: GeonodeApiVersion
     page_size: int
     api_version_settings: typing.Optional[
-        typing.Union[GeonodeCswSpecificConnectionSettings]] = None
+        typing.Union[GeonodeCswSpecificConnectionSettings]
+    ] = None
     auth_config: typing.Optional[str] = None
 
     @classmethod
@@ -128,7 +126,7 @@ class ConnectionSettings:
             reported_auth_cfg = settings.value("auth_config").strip()
         except AttributeError:
             reported_auth_cfg = None
-        api_version = settings.value("api_version")
+        api_version = GeonodeApiVersion[settings.value("api_version")]
         handler = get_api_version_settings_handler(api_version)
         if handler is not None:
             api_version_settings = handler.from_qgs_settings(settings)
@@ -207,11 +205,11 @@ class ConnectionManager(QtCore.QObject):
             settings.setValue("base_url", connection_settings.base_url)
             settings.setValue("page_size", connection_settings.page_size)
             settings.setValue("auth_config", connection_settings.auth_config)
-            settings.setValue("api_version", connection_settings.api_version)
+            settings.setValue("api_version", connection_settings.api_version.name)
             if connection_settings.api_version_settings is not None:
                 settings.setValue(
                     ApiVersionSpecificSettings.PREFIX,
-                    connection_settings.api_version_settings.to_qgs_settings()
+                    connection_settings.api_version_settings.to_qgs_settings(),
                 )
 
     def delete_connection(self, connection_id: uuid.UUID):

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -54,10 +54,12 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         ]
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(
-            QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
+            QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
+        )
         self.layout().insertWidget(0, self.bar)
         self.api_version_cmb.currentTextChanged.connect(
-            self.toggle_api_version_specific_widgets)
+            self.toggle_api_version_specific_widgets
+        )
         if connection_settings is not None:
             self.connection_id = connection_settings.id
             self.load_connection_settings(connection_settings)
@@ -75,7 +77,8 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         # disallow names that have a slash since that is not compatible with how we
         # are storing plugin state in QgsSettings
         self.name_le.setValidator(
-            QtGui.QRegExpValidator(QtCore.QRegExp("[^\\/]+"), self.name_le))
+            QtGui.QRegExpValidator(QtCore.QRegExp("[^\\/]+"), self.name_le)
+        )
         self.update_ok_buttons()
 
     def toggle_api_version_specific_widgets(self):
@@ -97,7 +100,8 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self.page_size_sb.setValue(connection_settings.page_size)
         if connection_settings.api_version_settings is not None:
             connection_settings.api_version_settings.fill_widgets(
-                self.version_specific_w)
+                self.version_specific_w
+            )
 
     def get_connection_settings(self) -> ConnectionSettings:
         api_version = GeonodeApiVersion[self.api_version_cmb.currentText().upper()]

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -6,9 +6,11 @@ from functools import partial
 
 from qgis.core import Qgis
 from qgis.gui import QgsMessageBar
-from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QSizePolicy
-from qgis.PyQt.QtGui import QRegExpValidator
-from qgis.PyQt.QtCore import QRegExp
+from qgis.PyQt import (
+    QtWidgets,
+    QtCore,
+    QtGui,
+)
 from qgis.PyQt.uic import loadUiType
 
 from ..apiclient import (
@@ -19,14 +21,16 @@ from ..apiclient.base import BaseGeonodeClient
 from ..conf import (
     ConnectionSettings,
     connections_manager,
+    get_api_version_settings_handler,
 )
+from ..utils import log
 
 DialogUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/connection_dialog.ui")
 )
 
 
-class ConnectionDialog(QDialog, DialogUi):
+class ConnectionDialog(QtWidgets.QDialog, DialogUi):
     connection_id: uuid.UUID
     geonode_client: BaseGeonodeClient = None
 
@@ -43,19 +47,23 @@ class ConnectionDialog(QDialog, DialogUi):
         self.api_version_cmb.insertItems(
             0, [member.name for member in api_version_names]
         )
+        self.toggle_api_version_specific_widgets()
         self._widgets_to_toggle_during_connection_test = [
             self.test_connection_btn,
             self.buttonBox,
         ]
         self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.bar.setSizePolicy(
+            QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
         self.layout().insertWidget(0, self.bar)
+        self.api_version_cmb.currentTextChanged.connect(
+            self.toggle_api_version_specific_widgets)
         if connection_settings is not None:
             self.connection_id = connection_settings.id
             self.load_connection_settings(connection_settings)
         else:
             self.connection_id = uuid.uuid4()
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+        self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(False)
         ok_signals = [
             self.name_le.textChanged,
             self.url_le.textChanged,
@@ -66,8 +74,20 @@ class ConnectionDialog(QDialog, DialogUi):
         self.detect_version_btn.clicked.connect(self.initiate_api_version_detection)
         # disallow names that have a slash since that is not compatible with how we
         # are storing plugin state in QgsSettings
-        self.name_le.setValidator(QRegExpValidator(QRegExp("[^\\/]+"), self.name_le))
+        self.name_le.setValidator(
+            QtGui.QRegExpValidator(QtCore.QRegExp("[^\\/]+"), self.name_le))
         self.update_ok_buttons()
+
+    def toggle_api_version_specific_widgets(self):
+        api_version = GeonodeApiVersion[self.api_version_cmb.currentText()]
+        handler = get_api_version_settings_handler(api_version)
+        previous_layout = self.version_specific_w.layout()
+        if previous_layout is not None:
+            _clear_layout(previous_layout)
+            previous_layout.deleteLater()
+        if handler is not None:
+            layout = handler.get_widgets()
+            self.version_specific_w.setLayout(layout)
 
     def load_connection_settings(self, connection_settings: ConnectionSettings):
         self.name_le.setText(connection_settings.name)
@@ -75,15 +95,25 @@ class ConnectionDialog(QDialog, DialogUi):
         self.authcfg_acs.setConfigId(connection_settings.auth_config)
         self.api_version_cmb.setCurrentText(connection_settings.api_version.name)
         self.page_size_sb.setValue(connection_settings.page_size)
+        if connection_settings.api_version_settings is not None:
+            connection_settings.api_version_settings.fill_widgets(
+                self.version_specific_w)
 
     def get_connection_settings(self) -> ConnectionSettings:
+        api_version = GeonodeApiVersion[self.api_version_cmb.currentText().upper()]
+        handler = get_api_version_settings_handler(api_version)
+        if handler is not None:
+            version_settings = handler.from_widgets(self.version_specific_w)
+        else:
+            version_settings = None
         return ConnectionSettings(
             id=self.connection_id,
             name=self.name_le.text().strip(),
             base_url=self.url_le.text().strip(),
             auth_config=self.authcfg_acs.configId(),
-            api_version=GeonodeApiVersion[self.api_version_cmb.currentText().upper()],
+            api_version=api_version,
             page_size=self.page_size_sb.value(),
+            api_version_settings=version_settings,
         )
 
     def test_connection(self):
@@ -111,10 +141,8 @@ class ConnectionDialog(QDialog, DialogUi):
         self.detect_api_version(self._autodetection_type_order[0])
 
     def detect_api_version(self, version: GeonodeApiVersion):
-
         connection_settings = self.get_connection_settings()
         connection_settings.api_version = version
-
         client = get_geonode_client(connection_settings)
         success_handler = partial(self.handle_autodetection_success, version)
         error_handler = partial(self.handle_autodetection_error, version)
@@ -147,5 +175,13 @@ class ConnectionDialog(QDialog, DialogUi):
 
     def update_ok_buttons(self):
         enabled_state = self.name_le.text() != "" and self.url_le.text() != ""
-        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(enabled_state)
+        self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enabled_state)
         self.test_connection_btn.setEnabled(enabled_state)
+
+
+def _clear_layout(layout: QtWidgets.QLayout):
+    while layout.count() > 0:
+        child = layout.takeAt(0)
+        widget = child.widget()
+        if widget is not None:
+            widget.deleteLater()

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -106,34 +106,25 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         }[service]
 
     def load_map_resource(self):
+        uri = self.geonode_resource.service_urls[GeonodeService.OGC_WMS]
+        log(f"service_uri: {uri}")
         self.toggle_service_url_buttons(False)
-
-        layer = QgsRasterLayer(
-            self.geonode_resource.service_urls[GeonodeService.OGC_WMS],
-            self.geonode_resource.title,
-            "wms",
-        )
-
+        layer = QgsRasterLayer(uri, self.geonode_resource.title, "wms")
         self.load_layer(layer)
 
     def load_raster_layer(self):
+        uri = self.geonode_resource.service_urls[GeonodeService.OGC_WCS]
+        log(f"service_uri: {uri}")
         self.toggle_service_url_buttons(False)
-        layer = QgsRasterLayer(
-            self.geonode_resource.service_urls[GeonodeService.OGC_WCS],
-            self.geonode_resource.title,
-            "wcs",
-        )
+        layer = QgsRasterLayer(uri, self.geonode_resource.title, "wcs")
 
         self.load_layer(layer)
 
     def load_vector_layer(self):
+        uri = self.geonode_resource.service_urls[GeonodeService.OGC_WFS]
+        log(f"service_uri: {uri}")
         self.toggle_service_url_buttons(False)
-        layer = QgsVectorLayer(
-            self.geonode_resource.service_urls[GeonodeService.OGC_WFS],
-            self.geonode_resource.title,
-            "WFS",
-        )
-
+        layer = QgsVectorLayer(uri, self.geonode_resource.title, "WFS")
         self.load_layer(layer)
 
     def load_layer(self, layer):

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>597</width>
-    <height>325</height>
+    <height>323</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,6 +40,12 @@
    </item>
    <item>
     <widget class="QgsAuthConfigSelect" name="authcfg_acs">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -114,14 +120,27 @@
           <property name="singleStep">
            <number>1</number>
           </property>
+          <property name="value">
+           <number>10</number>
+          </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item>
-       <widget class="QWidget" name="version_specific_w" native="true"/>
-      </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="test_connection_btn">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Test Connection</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -132,54 +151,20 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>50</height>
+       <height>13</height>
       </size>
      </property>
     </spacer>
    </item>
    <item>
-    <widget class="QPushButton" name="test_connection_btn">
-     <property name="text">
-      <string>Test Connection</string>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Help</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -49,64 +49,77 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="optionGroupBox">
+    <widget class="QGroupBox" name="options_gb">
      <property name="title">
       <string>Options</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>API version</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QComboBox" name="api_version_cmb">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>API version</string>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QPushButton" name="detect_version_btn">
+        <item row="0" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QComboBox" name="api_version_cmb">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="detect_version_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Auto-detect</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Page size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="page_size_sb">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text">
-           <string>Auto-detect</string>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>50</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
           </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Page size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="page_size_sb">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>50</number>
-        </property>
-        <property name="singleStep">
-         <number>1</number>
-        </property>
-       </widget>
+      <item>
+       <widget class="QWidget" name="version_specific_w" native="true"/>
       </item>
      </layout>
     </widget>

--- a/test/test_apiclient_csw.py
+++ b/test/test_apiclient_csw.py
@@ -52,9 +52,9 @@ def test_get_brief_geonode_resource():
     assert result.category == "planningcadastre"
     assert (
         result.service_urls[models.GeonodeService.OGC_WFS]
-        == f"https://master.demo.geonode.org/geoserver/ows?service=WFS&version=1.1.0&request=GetFeature&typename=geonode:tejo0&authkey={auth_config}"
+        == f"url='https://master.demo.geonode.org/geoserver/ows' typename='geonode:tejo0' version='auto' authcfg='{auth_config}'"
     )
     assert (
         result.service_urls[models.GeonodeService.OGC_WMS]
-        == f"crs=EPSG:4326&format=image/png&layers=geonode:tejo0&styles&url=https://master.demo.geonode.org/geoserver/ows&authkey={auth_config}"
+        == f"url=https://master.demo.geonode.org/geoserver/ows&format=image/png&layers=geonode:tejo0&crs=EPSG:4326&styles=&version=auto&authcfg={auth_config}"
     )


### PR DESCRIPTION
This PR implements initial support for private layers when using the GeoNode CSW endpoints.

GeoNode's CSW endpoint is not protected with OAuth2, it uses the browser session. This is likely a bug in GeoNode, as CSW is supposed to be a machine-machine interface and therefore is not likely to be accessed via browser. Regardless, since we need to support existing GeoNode deployments, this PR introduces a working solution, if not very elegant.

When using the CSW API for searching and retrieving records we perform a login to the main GeoNode GUI, emulating a browser. Upon login we receive the `sessionid` cookie, which is then included in subsequent requests. In order to be able to perform the login, we need to be given the  `username` and `password` by the user. This means that this type of connection uses two authentication methods:

- GeoNode session auth for querying the CSW endpoint for existing layers
- QGIS OAuth2 for getting a layer from GeoServer

Asking for the user's credentials and not storing them with QGIS auth framework is not very nice. However this seems like the only way to go forward, as GeoNode does not support HTTP Basic Auth (which would allow storing credentials in QGIS auth infrastructure) and uses the standard django login mechanism instead, which uses CSRF tokens.

Also included is support for loading a layer's SLD style. This also involves some "alternative" measures, since the GeoNode CSW endpoints do not expose any information about a layer's styling. We need to do a bunch of additional requests when retrieving the layer details in order to obtain the SLD URL. Again, it is not pretty, but seems to work OK.

fixes #98