### PR TITLE
Dynamically creating layer loading buttons for search items

### DIFF
--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -14,7 +14,10 @@ from qgis.PyQt.QtCore import (
 )
 
 from . import models
-from .models import GeonodeResourceType
+from .models import (
+    GeonodeResourceType,
+    GeonodeService,
+)
 from .base import BaseGeonodeClient
 
 
@@ -185,13 +188,21 @@ def _get_common_model_fields(
     resource_type = _get_resource_type(deserialized_resource)
     if resource_type == GeonodeResourceType.VECTOR_LAYER:
         service_urls = {
-            "wms": _get_wms_uri(auth_config, geonode_base_url, deserialized_resource),
-            "wfs": _get_wfs_uri(auth_config, geonode_base_url, deserialized_resource),
+            GeonodeService.OGC_WMS: _get_wms_uri(
+                auth_config, geonode_base_url, deserialized_resource
+            ),
+            GeonodeService.OGC_WFS: _get_wfs_uri(
+                auth_config, geonode_base_url, deserialized_resource
+            ),
         }
     elif resource_type == GeonodeResourceType.RASTER_LAYER:
         service_urls = {
-            "wms": _get_wms_uri(auth_config, geonode_base_url, deserialized_resource),
-            "wcs": _get_wcs_uri(auth_config, geonode_base_url, deserialized_resource),
+            GeonodeService.OGC_WMS: _get_wms_uri(
+                auth_config, geonode_base_url, deserialized_resource
+            ),
+            GeonodeService.OGC_WCS: _get_wcs_uri(
+                auth_config, geonode_base_url, deserialized_resource
+            ),
         }
     elif resource_type == GeonodeResourceType.MAP:
         service_urls = None  # FIXME: devise a way to retrieve WMS URL for maps

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -19,6 +19,7 @@ from qgis.PyQt.QtCore import (
 
 from . import models
 from .base import BaseGeonodeClient
+from .models import GeonodeService
 from ..utils import log
 
 
@@ -189,17 +190,17 @@ def _get_common_model_fields(
     resource_type = _get_resource_type(record)
     if resource_type == models.GeonodeResourceType.VECTOR_LAYER:
         service_urls = {
-            "wms": _get_wms_uri(record, layer_name, crs, auth_config),
-            "wfs": _get_wfs_uri(record, layer_name, auth_config),
+            GeonodeService.OGC_WMS: _get_wms_uri(record, layer_name, crs, auth_config),
+            GeonodeService.OGC_WFS: _get_wfs_uri(record, layer_name, auth_config),
         }
     elif resource_type == models.GeonodeResourceType.RASTER_LAYER:
         service_urls = {
-            "wms": _get_wms_uri(record, layer_name, crs, auth_config),
-            "wcs": _get_wcs_uri(record, layer_name, auth_config),
+            GeonodeService.OGC_WMS: _get_wms_uri(record, layer_name, crs, auth_config),
+            GeonodeService.OGC_WCS: _get_wcs_uri(record, layer_name, auth_config),
         }
     elif resource_type == models.GeonodeResourceType.MAP:
         service_urls = {
-            "wms": _get_wms_uri(record, layer_name, crs, auth_config),
+            GeonodeService.OGC_WMS: _get_wms_uri(record, layer_name, crs, auth_config),
         }
     else:
         service_urls = None

--- a/src/qgis_geonode/apiclient/models.py
+++ b/src/qgis_geonode/apiclient/models.py
@@ -11,6 +11,13 @@ from qgis.core import (
 )
 
 
+class GeonodeService(enum.Enum):
+    OGC_WMS = "wms"
+    OGC_WFS = "wfs"
+    OGC_WCS = "wcs"
+    FILE_DOWNLOAD = "file_download"
+
+
 class GeonodeResourceType(enum.Enum):
     VECTOR_LAYER = "vector"
     RASTER_LAYER = "raster"
@@ -53,7 +60,7 @@ class BriefGeonodeResource:
     gui_url: str
     keywords: typing.List[str]
     category: typing.Optional[str]
-    service_urls: typing.Dict[str, str]
+    service_urls: typing.Dict[GeonodeService, str]
 
     def __init__(
         self,
@@ -72,7 +79,7 @@ class BriefGeonodeResource:
         temporal_extent: typing.Optional[typing.List[dt.datetime]] = None,
         keywords: typing.Optional[typing.List[str]] = None,
         category: typing.Optional[str] = None,
-        service_urls: typing.Dict[str, str] = None,
+        service_urls: typing.Dict[GeonodeService, str] = None,
     ):
         self.pk = pk
         self.uuid = uuid

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -53,20 +53,6 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         self.message_bar = message_bar
         connection_settings = connections_manager.get_current_connection()
         self.client = get_geonode_client(connection_settings)
-
-        # self.wms_btn = QtWidgets.QPushButton("WMS")
-        # self.wms_btn.clicked.connect(self.load_map_resource)
-        # self.action_buttons_layout.insertWidget(1, self.wms_btn)
-        #
-        # if geonode_resource.resource_type == GeonodeResourceType.VECTOR_LAYER:
-        #     self.wfs_btn = QtWidgets.QPushButton("WFS")
-        #     self.wfs_btn.clicked.connect(self.load_vector_layer)
-        #     self.action_buttons_layout.insertWidget(2, self.wfs_btn)
-        # elif geonode_resource.resource_type == GeonodeResourceType.RASTER_LAYER:
-        #     self.wcs_btn = QtWidgets.QPushButton("WCS")
-        #     self.wcs_btn.clicked.connect(self.load_raster_layer)
-        #     self.action_buttons_layout.insertWidget(2, self.wcs_btn)
-
         for service_type in GeonodeService:
             url = geonode_resource.service_urls.get(service_type)
             if url is not None:
@@ -78,7 +64,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
                 button.clicked.connect(handler)
                 self.action_buttons_layout.insertWidget(order, button)
 
-        self.reset_ogc_buttons_state()
+        self.toggle_service_url_buttons(True)
         self.load_thumbnail()
 
     def _get_service_button_details(
@@ -147,7 +133,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
 
     def add_layer_to_project(self, layer: "QgsMapLayer"):
         QgsProject.instance().addMapLayer(layer)
-        self.reset_ogc_buttons_state()
+        self.toggle_service_url_buttons(True)
 
     def populate_metadata(self, layer, geonode_resource):
         metadata = layer.metadata()
@@ -235,14 +221,6 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
             )
         self.add_layer_to_project(layer)
 
-    def reset_ogc_buttons_state(self):
-        self.toggle_service_url_buttons(True)
-        # self.wms_btn.setEnabled(True)
-        # if self.geonode_resource.resource_type == GeonodeResourceType.RASTER_LAYER:
-        #     self.wcs_btn.setEnabled(True)
-        # if self.geonode_resource.resource_type == GeonodeResourceType.VECTOR_LAYER:
-        #     self.wfs_btn.setEnabled(True)
-
     def toggle_service_url_buttons(self, enabled: bool):
         for index in range(self.action_buttons_layout.count()):
             widget = self.action_buttons_layout.itemAt(index).widget()
@@ -275,4 +253,4 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
             level=Qgis.Warning,
         )
         QgsProject.instance().addMapLayer(layer)
-        self.reset_ogc_buttons_state()
+        self.toggle_service_url_buttons(True)

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -52,11 +52,19 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         self.message_bar = message_bar
         connection_settings = connections_manager.get_current_connection()
         self.client = get_geonode_client(connection_settings)
-        self.wms_btn.clicked.connect(self.load_map_resource)
-        self.wcs_btn.clicked.connect(self.load_raster_layer)
-        self.wfs_btn.clicked.connect(self.load_vector_layer)
 
-        self.temp_sld_style_path = None
+        self.wms_btn = QtWidgets.QPushButton("WMS")
+        self.wms_btn.clicked.connect(self.load_map_resource)
+        self.action_buttons_layout.insertWidget(1, self.wms_btn)
+
+        if geonode_resource.resource_type == GeonodeResourceType.VECTOR_LAYER:
+            self.wfs_btn = QtWidgets.QPushButton("WFS")
+            self.wfs_btn.clicked.connect(self.load_vector_layer)
+            self.action_buttons_layout.insertWidget(2, self.wfs_btn)
+        elif geonode_resource.resource_type == GeonodeResourceType.RASTER_LAYER:
+            self.wcs_btn = QtWidgets.QPushButton("WCS")
+            self.wcs_btn.clicked.connect(self.load_raster_layer)
+            self.action_buttons_layout.insertWidget(2, self.wcs_btn)
 
         self.reset_ogc_buttons_state()
         self.load_thumbnail()
@@ -207,12 +215,10 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
 
     def reset_ogc_buttons_state(self):
         self.wms_btn.setEnabled(True)
-        self.wcs_btn.setEnabled(
-            self.geonode_resource.resource_type == GeonodeResourceType.RASTER_LAYER
-        )
-        self.wfs_btn.setEnabled(
-            self.geonode_resource.resource_type == GeonodeResourceType.VECTOR_LAYER
-        )
+        if self.geonode_resource.resource_type == GeonodeResourceType.RASTER_LAYER:
+            self.wcs_btn.setEnabled(True)
+        if self.geonode_resource.resource_type == GeonodeResourceType.VECTOR_LAYER:
+            self.wfs_btn.setEnabled(True)
 
     def load_thumbnail(self):
         """Fetch the thumbnail from its remote URL and load it"""

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>768</width>
-    <height>221</height>
+    <height>280</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -111,7 +111,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="action_buttons_layout">
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
@@ -124,36 +124,6 @@
            </size>
           </property>
          </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="wms_btn">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to load resource as a WMS layer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>WMS</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="wfs_btn">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to load as a WFS layer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>WFS</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="wcs_btn">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to load resource as a WMS layer&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>WCS</string>
-          </property>
-         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="download_btn">

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -126,16 +126,6 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="download_btn">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Direct download&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>File Download</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QPushButton" name="browser_btn">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open resource in Browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/test/test_apiclient_csw.py
+++ b/test/test_apiclient_csw.py
@@ -11,8 +11,9 @@ from qgis_geonode.apiclient import (
 
 
 def test_get_brief_geonode_resource():
-    sample_response_path = Path(
-        __file__).parent / "_mock_geonode_data/layer_detail_response2.xml"
+    sample_response_path = (
+        Path(__file__).parent / "_mock_geonode_data/layer_detail_response2.xml"
+    )
     sample_response = ET.fromstring(sample_response_path.read_text("utf-8"))
     record = sample_response.find(f"{{{csw.Csw202Namespace.GMD.value}}}MD_Metadata")
     base_url = "https://dummy"
@@ -28,12 +29,32 @@ def test_get_brief_geonode_resource():
     assert result.spatial_extent.yMaximum() == pytest.approx(38.7166450851236)
     assert result.spatial_extent.yMinimum() == pytest.approx(38.6700664670482)
     assert result.crs.postgisSrid() == 4326
-    assert result.thumbnail_url == "https://master.demo.geonode.org/static/thumbs/layer-5db808ae-6671-11eb-91f3-0242ac150008-thumb.5cc326a7beec.png?v=c1509f76"
-    assert result.gui_url == "https://master.demo.geonode.org/layers/geonode_master_data:geonode:tejo0"
-    assert result.published_date.strftime("%Y-%m-%dT%H:%M:%SZ") == "2021-02-03T22:44:00Z"
-    assert result.temporal_extent[0].strftime("%Y-%m-%dT%H:%M:%S%z") == "2021-02-01T22:46:00+0000"
-    assert result.temporal_extent[1].strftime("%Y-%m-%dT%H:%M:%S%z") == "2021-02-28T22:46:00+0000"
+    assert (
+        result.thumbnail_url
+        == "https://master.demo.geonode.org/static/thumbs/layer-5db808ae-6671-11eb-91f3-0242ac150008-thumb.5cc326a7beec.png?v=c1509f76"
+    )
+    assert (
+        result.gui_url
+        == "https://master.demo.geonode.org/layers/geonode_master_data:geonode:tejo0"
+    )
+    assert (
+        result.published_date.strftime("%Y-%m-%dT%H:%M:%SZ") == "2021-02-03T22:44:00Z"
+    )
+    assert (
+        result.temporal_extent[0].strftime("%Y-%m-%dT%H:%M:%S%z")
+        == "2021-02-01T22:46:00+0000"
+    )
+    assert (
+        result.temporal_extent[1].strftime("%Y-%m-%dT%H:%M:%S%z")
+        == "2021-02-28T22:46:00+0000"
+    )
     assert result.keywords == ["blah", "Portugal"]
     assert result.category == "planningcadastre"
-    assert result.service_urls["wfs"] == f"https://master.demo.geonode.org/geoserver/ows?service=WFS&version=1.1.0&request=GetFeature&typename=geonode:tejo0&authkey={auth_config}"
-    assert result.service_urls["wms"] == f"crs=EPSG:4326&format=image/png&layers=geonode:tejo0&styles&url=https://master.demo.geonode.org/geoserver/ows&authkey={auth_config}"
+    assert (
+        result.service_urls[models.GeonodeService.OGC_WFS]
+        == f"https://master.demo.geonode.org/geoserver/ows?service=WFS&version=1.1.0&request=GetFeature&typename=geonode:tejo0&authkey={auth_config}"
+    )
+    assert (
+        result.service_urls[models.GeonodeService.OGC_WMS]
+        == f"crs=EPSG:4326&format=image/png&layers=geonode:tejo0&styles&url=https://master.demo.geonode.org/geoserver/ows&authkey={auth_config}"
+    )


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/67

Creates on the fly the OGC related buttons for loading layer from search result items, this enables to create and load only required buttons for each search item as search item can have different resource types.