### PR TITLE
Support for ordering when searching resources

### DIFF
--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -38,6 +38,8 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         layer_types: typing.Optional[typing.List[models.GeonodeResourceType]] = None,
         page: typing.Optional[int] = 1,
         page_size: typing.Optional[int] = 10,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         url = QUrl(f"{self.api_url}/layers/")
         query = QUrlQuery()
@@ -70,6 +72,10 @@ class GeonodeApiV2Client(BaseGeonodeClient):
             query.addQueryItem("filter{storeType}", "coverageStore")
         else:
             raise NotImplementedError
+        if ordering_field is not None:
+            if reverse_ordering:
+                ordering_field = "-{}".format(ordering_field)
+            query.addQueryItem("sort[]", ordering_field)
         url.setQuery(query.query())
         return url
 
@@ -86,6 +92,8 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         title: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         url = QUrl(f"{self.api_url}/maps/")
         query = QUrlQuery()
@@ -97,6 +105,10 @@ class GeonodeApiV2Client(BaseGeonodeClient):
             query.addQueryItem("filter{keywords.name.icontains}", keyword)
         if topic_category:
             query.addQueryItem("filter{category.identifier}", topic_category)
+        if ordering_field is not None:
+            if reverse_ordering:
+                ordering_field = "-{}".format(ordering_field)
+            query.addQueryItem("sort[]", ordering_field)
         url.setQuery(query.query())
         return url
 

--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -77,8 +77,11 @@ class GeonodeApiV2Client(BaseGeonodeClient):
             # current GeoNode API V2 doesn't support
             # ordering using  'title' field, so we default to 'name'
 
-            value = ordering_field.value \
-                if ordering_field != models.OrderingType.TITLE else 'name'
+            value = (
+                ordering_field.value
+                if ordering_field != models.OrderingType.TITLE
+                else "name"
+            )
             if reverse_ordering:
                 ordering_field_value = "-{}".format(value)
             else:

--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -38,7 +38,7 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         layer_types: typing.Optional[typing.List[models.GeonodeResourceType]] = None,
         page: typing.Optional[int] = 1,
         page_size: typing.Optional[int] = 10,
-        ordering_field: typing.Optional[str] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         url = QUrl(f"{self.api_url}/layers/")
@@ -73,9 +73,17 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         else:
             raise NotImplementedError
         if ordering_field is not None:
+            # TODO remove the below workaround
+            # current GeoNode API V2 doesn't support
+            # ordering using  'title' field, so we default to 'name'
+
+            value = ordering_field.value \
+                if ordering_field != models.OrderingType.TITLE else 'name'
             if reverse_ordering:
-                ordering_field = "-{}".format(ordering_field)
-            query.addQueryItem("sort[]", ordering_field)
+                ordering_field_value = "-{}".format(value)
+            else:
+                ordering_field_value = value
+            query.addQueryItem("sort[]", ordering_field_value)
         url.setQuery(query.query())
         return url
 
@@ -92,7 +100,7 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         title: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
-        ordering_field: typing.Optional[str] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         url = QUrl(f"{self.api_url}/maps/")
@@ -105,10 +113,13 @@ class GeonodeApiV2Client(BaseGeonodeClient):
             query.addQueryItem("filter{keywords.name.icontains}", keyword)
         if topic_category:
             query.addQueryItem("filter{category.identifier}", topic_category)
+
         if ordering_field is not None:
             if reverse_ordering:
-                ordering_field = "-{}".format(ordering_field)
-            query.addQueryItem("sort[]", ordering_field)
+                ordering_field_value = "-{}".format(ordering_field.value)
+            else:
+                ordering_field_value = ordering_field.value
+            query.addQueryItem("sort[]", ordering_field_value)
         url.setQuery(query.query())
         return url
 

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -46,6 +46,18 @@ class BaseGeonodeClient(QObject):
             auth_config=connection_settings.auth_config,
         )
 
+    def get_ordering_filter_name(
+        self,
+        ordering_type: models.OrderingType,
+        reverse_sort: typing.Optional[bool] = False,
+    ) -> str:
+        raise NotImplementedError
+
+    def get_search_result_identifier(
+        self, resource: models.BriefGeonodeResource
+    ) -> str:
+        raise NotImplementedError
+
     def get_layers_url_endpoint(
         self,
         page: typing.Optional[int] = 1,

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -55,6 +55,8 @@ class BaseGeonodeClient(QObject):
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
         layer_type: typing.Optional[models.GeonodeResourceType] = None,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         raise NotImplementedError
 
@@ -71,6 +73,8 @@ class BaseGeonodeClient(QObject):
         title: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         raise NotImplementedError
 
@@ -117,6 +121,8 @@ class BaseGeonodeClient(QObject):
         layer_types: typing.Optional[typing.List[models.GeonodeResourceType]] = None,
         page: typing.Optional[int] = 1,
         page_size: typing.Optional[int] = 10,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ):
         url = self.get_layers_url_endpoint(
             title=title,
@@ -126,6 +132,8 @@ class BaseGeonodeClient(QObject):
             layer_types=layer_types,
             page=page,
             page_size=page_size,
+            ordering_field=ordering_field,
+            reverse_ordering=reverse_ordering,
         )
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_layer_list)
@@ -165,6 +173,8 @@ class BaseGeonodeClient(QObject):
         title: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ):
         url = self.get_maps_url_endpoint(
             page=page,
@@ -172,6 +182,8 @@ class BaseGeonodeClient(QObject):
             title=title,
             keyword=keyword,
             topic_category=topic_category,
+            ordering_field=ordering_field,
+            reverse_ordering=reverse_ordering,
         )
         request = QNetworkRequest(url)
         self.run_task(request, self.handle_map_list)

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -55,7 +55,7 @@ class BaseGeonodeClient(QObject):
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
         layer_type: typing.Optional[models.GeonodeResourceType] = None,
-        ordering_field: typing.Optional[str] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         raise NotImplementedError
@@ -73,7 +73,7 @@ class BaseGeonodeClient(QObject):
         title: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
-        ordering_field: typing.Optional[str] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
     ) -> QUrl:
         raise NotImplementedError
@@ -121,7 +121,7 @@ class BaseGeonodeClient(QObject):
         layer_types: typing.Optional[typing.List[models.GeonodeResourceType]] = None,
         page: typing.Optional[int] = 1,
         page_size: typing.Optional[int] = 10,
-        ordering_field: typing.Optional[str] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
     ):
         url = self.get_layers_url_endpoint(
@@ -173,7 +173,7 @@ class BaseGeonodeClient(QObject):
         title: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
-        ordering_field: typing.Optional[str] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
     ):
         url = self.get_maps_url_endpoint(

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -182,6 +182,8 @@ class GeonodeCswClient(BaseGeonodeClient):
         layer_types: typing.Optional[typing.List[models.GeonodeResourceType]] = None,
         page: typing.Optional[int] = 1,
         page_size: typing.Optional[int] = 10,
+        ordering_field: typing.Optional[models.OrderingType] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ):
         """Get layers from the CSW endpoint
 
@@ -212,7 +214,15 @@ class GeonodeCswClient(BaseGeonodeClient):
             else:
                 raise RuntimeError("Unable to login")
         super().get_layers(
-            title, abstract, keyword, topic_category, layer_types, page, page_size
+            title,
+            abstract,
+            keyword,
+            topic_category,
+            layer_types,
+            page,
+            page_size,
+            ordering_field,
+            reverse_ordering,
         )
 
     def deserialize_response_contents(self, contents: QtCore.QByteArray) -> ET.Element:
@@ -242,9 +252,12 @@ class GeonodeCswClient(BaseGeonodeClient):
             )
             self.layer_list_received.emit(layers, pagination_info)
         else:
-            self.layer_list_received.emit(layers, models.GeoNodePaginationInfo(
-                total_records=0, current_page=1, page_size=self.PAGE_SIZE
-            ))
+            self.layer_list_received.emit(
+                layers,
+                models.GeoNodePaginationInfo(
+                    total_records=0, current_page=1, page_size=self.PAGE_SIZE
+                ),
+            )
 
     def handle_layer_detail(self, payload: ET.Element):
         """Parse the input payload into a GeonodeResource instance
@@ -395,7 +408,7 @@ def _get_common_model_fields(
         f"{{{Csw202Namespace.GMD.value}}}name/"
         f"{{{Csw202Namespace.GCO.value}}}CharacterString"
     )
-    layer_name = layer.text if layer is not None else ''
+    layer_name = layer.text if layer is not None else ""
 
     resource_type = _get_resource_type(record)
     if resource_type == models.GeonodeResourceType.VECTOR_LAYER:

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -96,6 +96,8 @@ class GeonodeCswClient(BaseGeonodeClient):
         layer_types: typing.Optional[typing.List[models.GeonodeResourceType]] = None,
         page: typing.Optional[int] = 1,
         page_size: typing.Optional[int] = 10,
+        ordering_field: typing.Optional[str] = None,
+        reverse_ordering: typing.Optional[bool] = False,
     ) -> QtCore.QUrl:
         url = QtCore.QUrl(f"{self.catalogue_url}")
         query = QtCore.QUrlQuery()
@@ -108,6 +110,13 @@ class GeonodeCswClient(BaseGeonodeClient):
         query.addQueryItem("typenames", self.TYPE_NAME)
         query.addQueryItem("outputschema", self.OUTPUT_SCHEMA)
         query.addQueryItem("elementsetname", "full")
+
+        if ordering_field is not None:
+            if not reverse_ordering:
+                ordering_value = "{}:A".format(ordering_field)
+            else:
+                ordering_value = "{}:D".format(ordering_field)
+            query.addQueryItem("sortby", ordering_value)
         # if any((title, abstract, keyword, topic_category, layer_types)):
         #     query.addQueryItem("constraintlanguage", "CQL_TEXT")
         #     constraint_values = []

--- a/src/qgis_geonode/apiclient/models.py
+++ b/src/qgis_geonode/apiclient/models.py
@@ -25,7 +25,7 @@ class GeonodeResourceType(enum.Enum):
 
 
 class OrderingType(enum.Enum):
-    TITLE = "title"
+    NAME = "name"
 
 
 @dataclasses.dataclass

--- a/src/qgis_geonode/apiclient/models.py
+++ b/src/qgis_geonode/apiclient/models.py
@@ -24,6 +24,10 @@ class GeonodeResourceType(enum.Enum):
     MAP = "map"
 
 
+class OrderingType(enum.Enum):
+    TITLE = "title"
+
+
 @dataclasses.dataclass
 class GeoNodePaginationInfo:
     total_records: int

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -217,6 +217,10 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         search_vector = self.vector_chb.isChecked()
         search_raster = self.raster_chb.isChecked()
         search_map = self.map_chb.isChecked()
+
+        if self.sort_field_cmb.currentText() is not None:
+            sorting_field = models.OrderingType[self.sort_field_cmb.currentText().upper()]
+
         if any((search_vector, search_raster, search_map)):
             if search_vector:
                 resource_types.append(models.GeonodeResourceType.VECTOR_LAYER)
@@ -237,7 +241,7 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
                 keyword=self.keyword_cmb.currentText() or None,
                 topic_category=self.category_cmb.currentText().lower() or None,
                 layer_types=resource_types,
-                ordering_field=self.sort_field_cmb.currentText().lower() or None,
+                ordering_field=sorting_field or models.OrderingType.TITLE,
                 reverse_ordering=self.reverse_order_chk.isChecked(),
             )
 
@@ -332,10 +336,7 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
     def load_sorting_fields(self):
         self.sort_field_cmb.addItems(
             [
-                "",
-                tr("Name"),
-                tr("Title"),
-                tr("Abstract"),
+                tr('Title'),
             ]
         )
 

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -13,9 +13,12 @@ from qgis.gui import (
     QgsSourceSelectProvider,
 )
 
-from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtNetwork import QNetworkReply
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt import (
+    QtCore,
+    QtGui,
+    QtNetwork,
+    QtWidgets,
+)
 from qgis.PyQt.uic import loadUiType
 
 from qgis.PyQt.QtWidgets import (
@@ -51,7 +54,7 @@ class GeonodeSourceSelectProvider(QgsSourceSelectProvider):
         return "geonodeprovider"
 
     def icon(self):
-        return QIcon(":/plugins/qgis_geonode/mIconGeonode.svg")
+        return QtGui.QIcon(":/plugins/qgis_geonode/mIconGeonode.svg")
 
     def text(self):
         return tr("GeoNode Plugin Provider")
@@ -64,6 +67,11 @@ class GeonodeSourceSelectProvider(QgsSourceSelectProvider):
 
 
 class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
+    sort_field_cmb: QtWidgets.QComboBox
+    search_btn: QtWidgets.QPushButton
+    next_btn: QtWidgets.QPushButton
+    previous_btn: QtWidgets.QPushButton
+
     def __init__(self, parent, fl, widgetMode):
         super().__init__(parent, fl, widgetMode)
         self.setupUi(self)
@@ -81,6 +89,13 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         self.connections_cmb.activated.connect(self.update_current_connection)
 
         self.current_page = 1
+        self.search_btn.setIcon(QtGui.QIcon(":/images/themes/default/search.svg"))
+        self.next_btn.setIcon(
+            QtGui.QIcon(":/images/themes/default/mActionAtlasNext.svg")
+        )
+        self.previous_btn.setIcon(
+            QtGui.QIcon(":/images/themes/default/mActionAtlasPrev.svg")
+        )
         self.search_btn.clicked.connect(
             partial(self.search_geonode, reset_pagination=True)
         )
@@ -97,7 +112,7 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         self.start_dte.clear()
         self.end_dte.clear()
         self.load_categories()
-        self.load_sorting_fields()
+        self.load_sorting_fields(selected_by_default=models.OrderingType.NAME)
 
     def add_connection(self):
         connection_dialog = ConnectionDialog()
@@ -199,6 +214,13 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         self.current_page = max(self.current_page - 1, 1)
         self.search_geonode()
 
+    def _get_api_client(self):
+        connection_name = self.connections_cmb.currentText()
+        connection_settings = connections_manager.find_connection_by_name(
+            connection_name
+        )
+        return get_geonode_client(connection_settings)
+
     def search_geonode(self, reset_pagination: bool = False):
         self.clear_search()
         self.search_btn.setEnabled(False)
@@ -209,7 +231,7 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         connection_settings = connections_manager.find_connection_by_name(
             connection_name
         )
-        client = get_geonode_client(connection_settings)
+        client = self._get_api_client()
         client.layer_list_received.connect(self.handle_layer_list)
         client.layer_list_received.connect(self.handle_pagination)
         client.error_received.connect(self.show_search_error)
@@ -217,12 +239,6 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         search_vector = self.vector_chb.isChecked()
         search_raster = self.raster_chb.isChecked()
         search_map = self.map_chb.isChecked()
-
-        if self.sort_field_cmb.currentText() is not None:
-            sorting_field = models.OrderingType[
-                self.sort_field_cmb.currentText().upper()
-            ]
-
         if any((search_vector, search_raster, search_map)):
             if search_vector:
                 resource_types.append(models.GeonodeResourceType.VECTOR_LAYER)
@@ -243,14 +259,16 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
                 keyword=self.keyword_cmb.currentText() or None,
                 topic_category=self.category_cmb.currentText().lower() or None,
                 layer_types=resource_types,
-                ordering_field=sorting_field or models.OrderingType.TITLE,
+                ordering_field=self.sort_field_cmb.currentData(QtCore.Qt.UserRole),
                 reverse_ordering=self.reverse_order_chk.isChecked(),
             )
 
     def show_search_error(self, error):
         self.message_bar.clearWidgets()
         self.search_btn.setEnabled(True)
-        network_error_enum = enum_mapping(QNetworkReply, QNetworkReply.NetworkError)
+        network_error_enum = enum_mapping(
+            QtNetwork.QNetworkReply, QtNetwork.QNetworkReply.NetworkError
+        )
         self.message_bar.pushMessage(
             tr("Problem in searching, network error {} - {}").format(
                 error, network_error_enum[error]
@@ -291,15 +309,18 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         layout = QVBoxLayout()
         layout.setContentsMargins(1, 1, 1, 1)
         layout.setSpacing(1)
+        client = self._get_api_client()
         for layer in layers:
             search_result_widget = SearchResultWidget(
-                self.message_bar, geonode_resource=layer
+                self.message_bar,
+                geonode_resource=layer,
+                api_client=client,
             )
             layout.addWidget(search_result_widget)
-            layout.setAlignment(search_result_widget, Qt.AlignTop)
+            layout.setAlignment(search_result_widget, QtCore.Qt.AlignTop)
         scroll_container.setLayout(layout)
-        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setWidget(scroll_container)
 
@@ -335,18 +356,20 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
             ]
         )
 
-    def load_sorting_fields(self):
-        self.sort_field_cmb.addItems(
-            [
-                tr("Title"),
-            ]
+    def load_sorting_fields(self, selected_by_default: models.OrderingType):
+        labels = {
+            models.OrderingType.NAME: tr("Name"),
+        }
+        for ordering_type, item_text in labels.items():
+            self.sort_field_cmb.addItem(item_text, ordering_type)
+        self.sort_field_cmb.setCurrentIndex(
+            self.sort_field_cmb.findData(selected_by_default, role=QtCore.Qt.UserRole)
         )
 
     def search_keywords(self):
         connection_name = self.connections_cmb.currentText()
         if connection_name:
-            connection = connections_manager.find_connection_by_name(connection_name)
-            client = get_geonode_client(connection)
+            client = self._get_api_client()
             client.keyword_list_received.connect(self.update_keywords)
             client.error_received.connect(self.show_search_error)
 

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -97,6 +97,7 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         self.start_dte.clear()
         self.end_dte.clear()
         self.load_categories()
+        self.load_sorting_fields()
 
     def add_connection(self):
         connection_dialog = ConnectionDialog()
@@ -236,6 +237,8 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
                 keyword=self.keyword_cmb.currentText() or None,
                 topic_category=self.category_cmb.currentText().lower() or None,
                 layer_types=resource_types,
+                ordering_field=self.sort_field_cmb.currentText().lower() or None,
+                reverse_ordering=self.reverse_order_chk.isChecked(),
             )
 
     def show_search_error(self, error):
@@ -323,6 +326,16 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
                 tr(IsoTopicCategory.ECONOMY.value),
                 tr(IsoTopicCategory.SOCIETY.value),
                 tr(IsoTopicCategory.IMAGERY_BASE_MAPS_EARTH_COVER.value),
+            ]
+        )
+
+    def load_sorting_fields(self):
+        self.sort_field_cmb.addItems(
+            [
+                "",
+                tr("Name"),
+                tr("Title"),
+                tr("Abstract"),
             ]
         )
 

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -219,7 +219,9 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
         search_map = self.map_chb.isChecked()
 
         if self.sort_field_cmb.currentText() is not None:
-            sorting_field = models.OrderingType[self.sort_field_cmb.currentText().upper()]
+            sorting_field = models.OrderingType[
+                self.sort_field_cmb.currentText().upper()
+            ]
 
         if any((search_vector, search_raster, search_map)):
             if search_vector:
@@ -336,7 +338,7 @@ class GeonodeDataSourceWidget(QgsAbstractDataSourceWidget, WidgetUi):
     def load_sorting_fields(self):
         self.sort_field_cmb.addItems(
             [
-                tr('Title'),
+                tr("Title"),
             ]
         )
 

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -21,6 +21,7 @@ from qgis.core import (
 from qgis.gui import QgsMessageBar
 
 from ..apiclient import get_geonode_client
+from ..apiclient.base import BaseGeonodeClient
 from ..apiclient.models import (
     BriefGeonodeResource,
     GeonodeResource,
@@ -41,11 +42,16 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         self,
         message_bar: QgsMessageBar,
         geonode_resource: BriefGeonodeResource,
+        api_client: BaseGeonodeClient,
         parent=None,
     ):
         super().__init__(parent)
         self.setupUi(self)
-        self.name_la.setText(f"<h3>{geonode_resource.title}</h3>")
+        self.name_la.setText(f"<h3>{geonode_resource.name}</h3>")
+
+        name = api_client.get_search_result_identifier(geonode_resource)
+        self.name_la.setText(f"<h3>{name}</h3>")
+
         if geonode_resource.resource_type is not None:
             self.resource_type_la.setText(geonode_resource.resource_type.value)
             icon_path = {

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>790</width>
-    <height>670</height>
+    <width>728</width>
+    <height>740</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -335,7 +335,20 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <widget class="QLabel" name="label_7">
        <property name="enabled">
@@ -347,44 +360,54 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBox_6">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnSave_3">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Save connections to file</string>
-       </property>
-       <property name="text">
-        <string>Save</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnLoad_3">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Load connections from file</string>
-       </property>
-       <property name="text">
-        <string>Load</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <item>
+        <widget class="QComboBox" name="comboBox_6">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnSave_3">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="toolTip">
+          <string>Save connections to file</string>
+         </property>
+         <property name="text">
+          <string>Save</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnLoad_3">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="toolTip">
+          <string>Load connections from file</string>
+         </property>
+         <property name="text">
+          <string>Load</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
       <widget class="QPushButton" name="search_btn">
+       <property name="minimumSize">
+        <size>
+         <width>143</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Load connections from file</string>
        </property>
@@ -394,21 +417,48 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Sort results by</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="sort_field_cmb"/>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="reverse_order_chk">
-       <property name="text">
-        <string>Reverse Order</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_9">
+           <property name="styleSheet">
+            <string notr="true">padding-left:25%;</string>
+           </property>
+           <property name="text">
+            <string>Sort results by</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="sort_field_cmb">
+           <property name="minimumSize">
+            <size>
+             <width>143</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="reverse_order_chk">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string>Reverse order</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
@@ -499,7 +549,6 @@
   <zorder>scroll_area</zorder>
   <zorder>groupBox</zorder>
   <zorder>search_group_box</zorder>
-  <zorder>search_btn</zorder>
   <zorder>buttonBox</zorder>
   <zorder>title_le</zorder>
   <zorder>label</zorder>

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Connection</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -103,222 +103,45 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Title</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="title_le">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-       </property>
-       <property name="whatsThis">
-        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QgsCollapsibleGroupBox" name="search_group_box">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Additional search filters</string>
+      <string>Search</string>
      </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <property name="collapsed">
-      <bool>false</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Abstract</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="abstract_le">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Keywords</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QComboBox" name="keyword_cmb">
+         <widget class="QLabel" name="label">
           <property name="enabled">
            <bool>true</bool>
           </property>
+          <property name="text">
+           <string>Title</string>
+          </property>
          </widget>
         </item>
         <item>
-         <widget class="QToolButton" name="keyword_tool_btn">
-          <property name="text">
-           <string>...</string>
+         <widget class="QLineEdit" name="title_le">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
+          </property>
+          <property name="whatsThis">
+           <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
+      <item>
+       <widget class="QgsCollapsibleGroupBox" name="search_group_box">
         <property name="enabled">
          <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Topic Category</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="category_cmb">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Resource types</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QCheckBox" name="vector_chb">
-          <property name="text">
-           <string>Vector</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">resource_types_btngrp</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="raster_chb">
-          <property name="text">
-           <string>Raster</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">resource_types_btngrp</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="map_chb">
-          <property name="text">
-           <string>Map</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">resource_types_btngrp</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Start</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QgsDateTimeEdit" name="start_dte">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="allowNull">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>End</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QgsDateTimeEdit" name="end_dte">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0" colspan="2">
-       <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
-        <property name="enabled">
-         <bool>false</bool>
         </property>
         <property name="title">
-         <string>Spatial Extent</string>
+         <string>Advanced</string>
         </property>
         <property name="checkable">
          <bool>false</bool>
@@ -327,84 +150,269 @@
          <bool>false</bool>
         </property>
         <property name="collapsed">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Abstract</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="abstract_le">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Keywords</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QComboBox" name="keyword_cmb">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="keyword_tool_btn">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Topic Category</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QComboBox" name="category_cmb">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Resource types</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QCheckBox" name="vector_chb">
+             <property name="text">
+              <string>Vector</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">resource_types_btngrp</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="raster_chb">
+             <property name="text">
+              <string>Raster</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">resource_types_btngrp</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="map_chb">
+             <property name="text">
+              <string>Map</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">resource_types_btngrp</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Start</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QgsDateTimeEdit" name="start_dte">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="allowNull">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>End</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QgsDateTimeEdit" name="end_dte">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0" colspan="2">
+          <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="title">
+            <string>Spatial Extent</string>
+           </property>
+           <property name="checkable">
+            <bool>false</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <property name="collapsed">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="label_7">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Stored searches</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QComboBox" name="comboBox_6">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="btnSave_3">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Save connections to file</string>
+            </property>
+            <property name="text">
+             <string>Save</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="btnLoad_3">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Load connections from file</string>
+            </property>
+            <property name="text">
+             <string>Load</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_7">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Stored searches</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_6">
-       <item>
-        <widget class="QComboBox" name="comboBox_6">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnSave_3">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="toolTip">
-          <string>Save connections to file</string>
-         </property>
-         <property name="text">
-          <string>Save</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnLoad_3">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="toolTip">
-          <string>Load connections from file</string>
-         </property>
-         <property name="text">
-          <string>Load</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_8">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QPushButton" name="search_btn">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
-         <width>143</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
@@ -417,55 +425,91 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_5">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_9">
-           <property name="styleSheet">
-            <string notr="true">padding-left:25%;</string>
-           </property>
-           <property name="text">
-            <string>Sort results by</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="sort_field_cmb">
-           <property name="minimumSize">
-            <size>
-             <width>143</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="reverse_order_chk">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
-         <property name="text">
-          <string>Reverse order</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QPushButton" name="previous_btn">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to previous page&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Previous</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="next_btn">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to next page&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Next</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_9">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <property name="text">
+        <string>Sort by</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="sort_field_cmb">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="reverse_order_chk">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Reverse order</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_12">
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
-      <spacer name="horizontalSpacer_2">
+      <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -480,27 +524,7 @@
      <item>
       <widget class="QLabel" name="resultsLabel">
        <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="previous_btn">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to previous page&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Previous</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="next_btn">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Go to next page&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Next</string>
+        <string>Zero Results</string>
        </property>
       </widget>
      </item>
@@ -528,8 +552,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>770</width>
-        <height>95</height>
+        <width>708</width>
+        <height>122</height>
        </rect>
       </property>
      </widget>
@@ -546,15 +570,6 @@
     </widget>
    </item>
   </layout>
-  <zorder>scroll_area</zorder>
-  <zorder>groupBox</zorder>
-  <zorder>search_group_box</zorder>
-  <zorder>buttonBox</zorder>
-  <zorder>title_le</zorder>
-  <zorder>label</zorder>
-  <zorder>sort_field_cmb</zorder>
-  <zorder>reverse_order_chk</zorder>
-  <zorder>label_9</zorder>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -382,14 +382,35 @@
     </layout>
    </item>
    <item>
-    <widget class="QPushButton" name="search_btn">
-     <property name="toolTip">
-      <string>Load connections from file</string>
-     </property>
-     <property name="text">
-      <string>Search Geonode</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QPushButton" name="search_btn">
+       <property name="toolTip">
+        <string>Load connections from file</string>
+       </property>
+       <property name="text">
+        <string>Search Geonode</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>Sort results by</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="sort_field_cmb"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="reverse_order_chk">
+       <property name="text">
+        <string>Reverse Order</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_12">
@@ -482,6 +503,9 @@
   <zorder>buttonBox</zorder>
   <zorder>title_le</zorder>
   <zorder>label</zorder>
+  <zorder>sort_field_cmb</zorder>
+  <zorder>reverse_order_chk</zorder>
+  <zorder>label_9</zorder>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/63

Adds ordering parameter in the GeonodeClient backend and new UI items to support ordering when searching for resources.
Currently the implementation works on only the "name" field, when using others fields including "title" and "abstract" the search results into a "ProtocolInvalidError".

