### PR TITLE
Open GeoNode layer page from the layer properties

### DIFF
--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -67,6 +67,8 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         self.toggle_service_url_buttons(True)
         self.load_thumbnail()
 
+        self.browser_btn.clicked.connect(self.open_resource_page)
+
     def _get_service_button_details(
         self, service: GeonodeService
     ) -> typing.Tuple[str, int, typing.Callable]:
@@ -254,3 +256,19 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         )
         QgsProject.instance().addMapLayer(layer)
         self.toggle_service_url_buttons(True)
+
+    def open_resource_page(self):
+        if self.geonode_resource.gui_url is not None:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl(self.geonode_resource.gui_url))
+        else:
+            log(
+                "Couldn't open resource in browser page, the resource"
+                "doesn't contain GeoNode layer page URL"
+            )
+            self.message_bar.pushMessage(
+                tr(
+                    "Couldn't open resource in browser page, the resource"
+                    "doesn't contain GeoNode layer page URL"
+                ),
+                level=Qgis.Critical,
+            )

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -66,7 +66,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
 
         self.toggle_service_url_buttons(True)
         self.load_thumbnail()
-
+        self.browser_btn.setIcon(QtGui.QIcon(":/plugins/qgis_geonode/mIconGeonode.svg"))
         self.browser_btn.clicked.connect(self.open_resource_page)
 
     def _get_service_button_details(

--- a/src/qgis_geonode/ui/qgis_geonode_layer_dialog.ui
+++ b/src/qgis_geonode/ui/qgis_geonode_layer_dialog.ui
@@ -58,7 +58,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QPushButton" name="btnSave_4">
+      <widget class="QPushButton" name="open_page_btn">
        <property name="toolTip">
         <string>Save connections to file</string>
        </property>

--- a/src/qgis_geonode/ui/search_result_widget.ui
+++ b/src/qgis_geonode/ui/search_result_widget.ui
@@ -126,7 +126,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="browser_btn">
+         <widget class="QToolButton" name="browser_btn">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open resource in Browser&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/58

Connects the "Open in Browser" button in the plugin custom widget available in the layer properties to open the layer GeoNode detail page in the default browser.

Screenshot
![open_in_browser](https://user-images.githubusercontent.com/2663775/109104902-f01bdb80-773d-11eb-8dae-86cfde4092a8.gif)
