### PR TITLE
Fix search button state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Load layers asynchronously
 - Add ordering of search results
 - Improve feedback shown when searching and loading layers
 - Fix incorrect visibility of the Search/Next/Previous search buttons

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -13,6 +13,7 @@ from qgis.PyQt import (
 )
 
 from . import models
+from ..utils import log
 
 
 class BaseGeonodeClient(QtCore.QObject):
@@ -238,13 +239,8 @@ class BaseGeonodeClient(QtCore.QObject):
             http_status_reason = reply.attribute(
                 QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute
             )
-            QgsMessageLog.logMessage(
-                f"requested url: {reply.url().toString()}", "qgis_geonode"
-            )
-            QgsMessageLog.logMessage(
-                f"received error: {qt_error} http_status: {http_status_code}",
-                "qgis_geonode",
-            )
+            log(f"requested url: {reply.url().toString()}")
+            log(f"received error: {qt_error} http_status: {http_status_code}")
             self.error_received.emit(
                 qt_error, http_status_code or 0, http_status_reason or ""
             )

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -6,31 +6,25 @@ from qgis.core import (
     QgsMessageLog,
     QgsNetworkContentFetcherTask,
 )
-from qgis.PyQt.QtCore import (
-    QByteArray,
-    QObject,
-    QUrl,
-    pyqtSignal,
+from qgis.PyQt import (
+    QtCore,
+    QtNetwork,
+    QtXml,
 )
-from qgis.PyQt.QtNetwork import (
-    QNetworkReply,
-    QNetworkRequest,
-)
-from qgis.PyQt import QtXml
 
 from . import models
 
 
-class BaseGeonodeClient(QObject):
+class BaseGeonodeClient(QtCore.QObject):
     auth_config: str
     base_url: str
 
-    layer_list_received = pyqtSignal(list, models.GeoNodePaginationInfo)
-    layer_detail_received = pyqtSignal(models.GeonodeResource)
-    style_detail_received = pyqtSignal(QtXml.QDomElement)
-    layer_styles_received = pyqtSignal(list)
-    map_list_received = pyqtSignal(list, models.GeoNodePaginationInfo)
-    error_received = pyqtSignal(int)
+    layer_list_received = QtCore.pyqtSignal(list, models.GeoNodePaginationInfo)
+    layer_detail_received = QtCore.pyqtSignal(models.GeonodeResource)
+    style_detail_received = QtCore.pyqtSignal(QtXml.QDomElement)
+    layer_styles_received = QtCore.pyqtSignal(list)
+    map_list_received = QtCore.pyqtSignal(list, models.GeoNodePaginationInfo)
+    error_received = QtCore.pyqtSignal(str, int, str)
 
     def __init__(
         self, base_url: str, *args, auth_config: typing.Optional[str] = None, **kwargs
@@ -69,10 +63,12 @@ class BaseGeonodeClient(QObject):
         layer_type: typing.Optional[models.GeonodeResourceType] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-    ) -> QUrl:
+    ) -> QtCore.QUrl:
         raise NotImplementedError
 
-    def get_layer_detail_url_endpoint(self, id_: typing.Union[int, uuid.UUID]) -> QUrl:
+    def get_layer_detail_url_endpoint(
+        self, id_: typing.Union[int, uuid.UUID]
+    ) -> QtCore.QUrl:
         raise NotImplementedError
 
     def get_layer_styles_url_endpoint(self, layer_id: int):
@@ -87,13 +83,13 @@ class BaseGeonodeClient(QObject):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-    ) -> QUrl:
+    ) -> QtCore.QUrl:
         raise NotImplementedError
 
-    def deserialize_response_contents(self, contents: QByteArray) -> typing.Any:
+    def deserialize_response_contents(self, contents: QtCore.QByteArray) -> typing.Any:
         raise NotImplementedError
 
-    def deserialize_sld_style(self, raw_sld: QByteArray) -> QtXml.QDomDocument:
+    def deserialize_sld_style(self, raw_sld: QtCore.QByteArray) -> QtXml.QDomDocument:
         sld_doc = QtXml.QDomDocument()
         # in the line below, `True` means use XML namespaces and it is crucial for
         # QGIS to be able to load the SLD
@@ -147,7 +143,7 @@ class BaseGeonodeClient(QObject):
             ordering_field=ordering_field,
             reverse_ordering=reverse_ordering,
         )
-        request = QNetworkRequest(url)
+        request = QtNetwork.QNetworkRequest(url)
         self.run_task(request, self.handle_layer_list)
 
     def get_layer_detail_from_brief_resource(
@@ -156,11 +152,13 @@ class BaseGeonodeClient(QObject):
         raise NotImplementedError
 
     def get_layer_detail(self, id_: typing.Union[int, uuid.UUID]):
-        request = QNetworkRequest(self.get_layer_detail_url_endpoint(id_))
+        request = QtNetwork.QNetworkRequest(self.get_layer_detail_url_endpoint(id_))
         self.run_task(request, self.handle_layer_detail)
 
     def get_layer_styles(self, layer_id: int):
-        request = QNetworkRequest(self.get_layer_styles_url_endpoint(layer_id))
+        request = QtNetwork.QNetworkRequest(
+            self.get_layer_styles_url_endpoint(layer_id)
+        )
         self.run_task(request, self.handle_layer_style_list)
 
     def get_layer_style(
@@ -171,7 +169,7 @@ class BaseGeonodeClient(QObject):
         else:
             style_details = [i for i in layer.styles if i.name == style_name][0]
             style_url = style_details.sld_url
-        request = QNetworkRequest(QUrl(style_url))
+        request = QtNetwork.QNetworkRequest(QtCore.QUrl(style_url))
         self.run_task(
             request,
             self.handle_layer_style_detail,
@@ -197,7 +195,7 @@ class BaseGeonodeClient(QObject):
             ordering_field=ordering_field,
             reverse_ordering=reverse_ordering,
         )
-        request = QNetworkRequest(url)
+        request = QtNetwork.QNetworkRequest(url)
         self.run_task(request, self.handle_map_list)
 
     def run_task(
@@ -224,12 +222,45 @@ class BaseGeonodeClient(QObject):
         deserializer: typing.Callable,
     ):
         """Process GeoNode API response and dispatch the appropriate handler"""
-        reply: QNetworkReply = task.reply()
+        reply: QtNetwork.QNetworkReply = task.reply()
         error = reply.error()
-        if error == QNetworkReply.NoError:
-            contents: QByteArray = reply.readAll()
+        if error == QtNetwork.QNetworkReply.NoError:
+            contents: QtCore.QByteArray = reply.readAll()
             payload = deserializer(contents)
             handler(payload)
         else:
-            QgsMessageLog.logMessage("received error", "qgis_geonode")
-            self.error_received.emit(error)
+            qt_error = _get_qt_error(
+                QtNetwork.QNetworkReply, QtNetwork.QNetworkReply.NetworkError, error
+            )
+            http_status_code = reply.attribute(
+                QtNetwork.QNetworkRequest.HttpStatusCodeAttribute
+            )
+            http_status_reason = reply.attribute(
+                QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute
+            )
+            QgsMessageLog.logMessage(
+                f"requested url: {reply.url().toString()}", "qgis_geonode"
+            )
+            QgsMessageLog.logMessage(
+                f"received error: {qt_error} http_status: {http_status_code}",
+                "qgis_geonode",
+            )
+            self.error_received.emit(
+                qt_error, http_status_code or 0, http_status_reason or ""
+            )
+
+
+def _get_qt_error(cls, enum, error: QtNetwork.QNetworkReply.NetworkError) -> str:
+    """workaround for accessing unsubscriptable sip enum types
+
+    from https://stackoverflow.com/a/39677321
+
+    """
+
+    mapping = {}
+    for key in dir(cls):
+        value = getattr(cls, key)
+        if isinstance(value, enum):
+            mapping[key] = value
+            mapping[value] = key
+    return mapping[error]

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -332,7 +332,6 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.message_bar.clearWidgets()
         self.toggle_search_buttons()
 
-
     def clear_search_results(self):
         self.scroll_area.setWidget(QtWidgets.QWidget())
         self.resultsLabel.clear()

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -358,8 +358,8 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             client = self._get_api_client()
             for layer in layer_list:
                 search_result_widget = SearchResultWidget(
-                    geonode_resource=layer,
-                    api_client=client,
+                    layer,
+                    client,
                 )
                 layout.addWidget(search_result_widget)
                 layout.setAlignment(search_result_widget, QtCore.Qt.AlignTop)

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -8,7 +8,6 @@ import qgis.gui
 from qgis.PyQt import (
     QtCore,
     QtGui,
-    QtNetwork,
     QtWidgets,
 )
 from qgis.PyQt.uic import loadUiType
@@ -19,7 +18,6 @@ from ..conf import connections_manager
 from ..gui.connection_dialog import ConnectionDialog
 from ..gui.search_result_widget import SearchResultWidget
 from ..utils import (
-    enum_mapping,
     IsoTopicCategory,
     tr,
 )
@@ -52,31 +50,54 @@ class GeonodeSourceSelectProvider(qgis.gui.QgsSourceSelectProvider):
 
 
 class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
+    abstract_le: QtWidgets.QLineEdit
+    category_cmb: QtWidgets.QComboBox
     connections_cmb: QtWidgets.QComboBox
-    sort_field_cmb: QtWidgets.QComboBox
-    search_btn: QtWidgets.QPushButton
-    next_btn: QtWidgets.QPushButton
-    previous_btn: QtWidgets.QPushButton
-    message_bar: qgis.gui.QgsMessageBar
-    resource_types_btngrp: QtWidgets.QButtonGroup
     current_page: int = 0
+    edit_connection_btn: QtWidgets.QPushButton
+    end_dte: qgis.gui.QgsDateTimeEdit
+    delete_connection_btn: QtWidgets.QPushButton
+    keyword_cmb: QtWidgets.QComboBox
+    keyword_tool_btn: QtWidgets.QToolButton
+    load_connection_btn: QtWidgets.QPushButton
+    map_chb: QtWidgets.QCheckBox
+    message_bar: qgis.gui.QgsMessageBar
+    next_btn: QtWidgets.QPushButton
+    new_connection_btn: QtWidgets.QPushButton
+    pagination_info_la: QtWidgets.QLabel
+    previous_btn: QtWidgets.QPushButton
+    raster_chb: QtWidgets.QCheckBox
+    resource_types_btngrp: QtWidgets.QButtonGroup
+    reverse_order_chb: QtWidgets.QCheckBox
+    save_connection_btn: QtWidgets.QPushButton
+    scroll_area: QtWidgets.QScrollArea
+    search_btn: QtWidgets.QPushButton
+    sort_field_cmb: QtWidgets.QComboBox
+    start_dte: qgis.gui.QgsDateTimeEdit
+    title_le: QtWidgets.QLineEdit
     total_pages: int = 0
-    search_status: bool
+    vector_chb: QtWidgets.QCheckBox
+
+    search_started = QtCore.pyqtSignal()
+    search_finished = QtCore.pyqtSignal(str)
+    load_layer_started = QtCore.pyqtSignal()
+    load_layer_finished = QtCore.pyqtSignal()
 
     def __init__(self, parent, fl, widgetMode):
         super().__init__(parent, fl, widgetMode)
         self.setupUi(self)
         self.project = qgis.core.QgsProject.instance()
         self.resource_types_btngrp.buttonClicked.connect(self.toggle_search_buttons)
-        self.btnNew.clicked.connect(self.add_connection)
-        self.btnEdit.clicked.connect(self.edit_connection)
-        self.btnDelete.clicked.connect(self.delete_connection)
+        self.new_connection_btn.clicked.connect(self.add_connection)
+        self.edit_connection_btn.clicked.connect(self.edit_connection)
+        self.delete_connection_btn.clicked.connect(self.delete_connection)
         self.connections_cmb.currentIndexChanged.connect(
             self.toggle_connection_management_buttons
         )
+        self.search_started.connect(self.handle_search_start)
+        self.search_finished.connect(self.handle_search_end)
 
-        self.search_status = False
-        self.connections_cmb.currentIndexChanged.connect(self.toggle_search_controls)
+        self.connections_cmb.currentIndexChanged.connect(self.reset_search_controls)
         self.update_connections_combobox()
         self.toggle_connection_management_buttons()
         self.connections_cmb.activated.connect(self.update_current_connection)
@@ -107,6 +128,34 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.end_dte.clear()
         self.load_categories()
         self.load_sorting_fields(selected_by_default=models.OrderingType.NAME)
+
+        # we use these to control enabling/disabling UI controls during searches
+        self._connection_controls = [
+            self.connections_cmb,
+            self.new_connection_btn,
+            self.edit_connection_btn,
+            self.delete_connection_btn,
+            self.load_connection_btn,
+            self.save_connection_btn,
+        ]
+        self._search_controls = [
+            self.title_le,
+            self.abstract_le,
+            self.keyword_cmb,
+            self.keyword_tool_btn,
+            self.category_cmb,
+            self.vector_chb,
+            self.raster_chb,
+            self.map_chb,
+            self.start_dte,
+            self.end_dte,
+            self.search_btn,
+            self.next_btn,
+            self.previous_btn,
+            self.sort_field_cmb,
+            self.reverse_order_chb,
+            self.pagination_info_la,
+        ]
 
     def add_connection(self):
         connection_dialog = ConnectionDialog()
@@ -167,7 +216,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             if self.connections_cmb.currentText() != "":
                 for check_box in self.resource_types_btngrp.buttons():
                     if check_box.isChecked():
-                        enable_search = not self.search_status
+                        enable_search = True
                         enable_previous = self.current_page > 1
                         enable_next = self.current_page < self.total_pages
                         break
@@ -178,10 +227,10 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
     def toggle_connection_management_buttons(self):
         current_name = self.connections_cmb.currentText()
         enabled = current_name != ""
-        self.btnEdit.setEnabled(enabled)
-        self.btnDelete.setEnabled(enabled)
+        self.edit_connection_btn.setEnabled(enabled)
+        self.delete_connection_btn.setEnabled(enabled)
 
-    def toggle_search_controls(self):
+    def reset_search_controls(self):
         self.clear_search_results()
         self.current_page = 1
         self.total_pages = 1
@@ -201,7 +250,6 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             QtWidgets.QMessageBox.Yes,
             QtWidgets.QMessageBox.No,
         )
-
         return confirmation == QtWidgets.QMessageBox.Yes
 
     def request_next_page(self):
@@ -233,17 +281,13 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.message_bar.pushMessage(message, level=level)
 
     def search_geonode(self, reset_pagination: bool = False):
-        self.clear_search_results()
-        self.search_status = True
-        self.toggle_search_buttons(enable=False)
-        self.show_progress(tr("Searching..."))
+        self.search_started.emit()
         connection_name = self.connections_cmb.currentText()
         connection_settings = connections_manager.find_connection_by_name(
             connection_name
         )
         client = self._get_api_client()
         client.layer_list_received.connect(self.handle_layer_list)
-        client.layer_list_received.connect(self.handle_pagination)
         client.error_received.connect(self.show_search_error)
         resource_types = []
         search_vector = self.vector_chb.isChecked()
@@ -271,43 +315,70 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
                 topic_category=self.category_cmb.currentText().lower() or None,
                 layer_types=resource_types,
                 ordering_field=self.sort_field_cmb.currentData(QtCore.Qt.UserRole),
-                reverse_ordering=self.reverse_order_chk.isChecked(),
+                reverse_ordering=self.reverse_order_chb.isChecked(),
             )
 
-    def show_search_error(self, error):
+    def toggle_search_controls(self, enabled: bool):
+        for widget in self._connection_controls + self._search_controls:
+            widget.setEnabled(enabled)
+
+    def handle_search_start(self):
+        self.toggle_search_controls(False)
+        self.clear_search_results()
+        self.show_progress(tr("Searching..."))
+
+    def handle_search_end(self, message: str):
         self.message_bar.clearWidgets()
-        self.search_status = False
+        if message != "":
+            self.show_message(message, level=qgis.core.Qgis.Critical)
+        self.toggle_search_controls(True)
         self.toggle_search_buttons()
-        network_error_enum = enum_mapping(
-            QtNetwork.QNetworkReply, QtNetwork.QNetworkReply.NetworkError
-        )
-        self.show_message(
-            tr(
-                f"Problem in searching, network "
-                f"error {error} - {network_error_enum[error]}"
-            ),
-            level=qgis.core.Qgis.Critical,
-        )
+
+    def show_search_error(
+        self, qt_error_message: str, http_status_code: int, http_status_reason: str
+    ):
+        if http_status_code != 0:
+            http_error = f"{http_status_code!r} - {http_status_reason!r}"
+        else:
+            http_error = ""
+        error_message = f"Request error: {' '.join((qt_error_message, http_error))}"
+        self.search_finished.emit(error_message)
 
     def handle_layer_list(
         self,
         layer_list: typing.List[models.BriefGeonodeResource],
         pagination_info: models.GeoNodePaginationInfo,
     ):
+        self.handle_pagination(pagination_info)
         if len(layer_list) > 0:
-            self.populate_scroll_area(layer_list)
+            scroll_container = QtWidgets.QWidget()
+            layout = QtWidgets.QVBoxLayout()
+            layout.setContentsMargins(1, 1, 1, 1)
+            layout.setSpacing(1)
+            client = self._get_api_client()
+            for layer in layer_list:
+                search_result_widget = SearchResultWidget(
+                    geonode_resource=layer,
+                    api_client=client,
+                )
+                layout.addWidget(search_result_widget)
+                layout.setAlignment(search_result_widget, QtCore.Qt.AlignTop)
+            scroll_container.setLayout(layout)
+            self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+            self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            self.scroll_area.setWidgetResizable(True)
+            self.scroll_area.setWidget(scroll_container)
+            self.message_bar.clearWidgets()
+        self.search_finished.emit("")
 
     def handle_pagination(
         self,
-        layer_list: typing.List[models.BriefGeonodeResource],
         pagination_info: models.GeoNodePaginationInfo,
     ):
         self.current_page = pagination_info.current_page
         self.total_pages = pagination_info.total_pages
-        self.search_status = False
-        self.toggle_search_buttons()
         if pagination_info.total_records > 0:
-            self.resultsLabel.setText(
+            self.pagination_info_la.setText(
                 tr(
                     f"Showing page {self.current_page} of "
                     f"{pagination_info.total_pages} ({pagination_info.total_records} "
@@ -315,33 +386,11 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
                 )
             )
         else:
-            self.resultsLabel.setText(tr("No results found"))
-
-    def populate_scroll_area(self, layers: typing.List[models.BriefGeonodeResource]):
-        scroll_container = QtWidgets.QWidget()
-        layout = QtWidgets.QVBoxLayout()
-        layout.setContentsMargins(1, 1, 1, 1)
-        layout.setSpacing(1)
-        client = self._get_api_client()
-        for layer in layers:
-            search_result_widget = SearchResultWidget(
-                geonode_resource=layer,
-                api_client=client,
-            )
-            layout.addWidget(search_result_widget)
-            layout.setAlignment(search_result_widget, QtCore.Qt.AlignTop)
-        scroll_container.setLayout(layout)
-        self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
-        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setWidget(scroll_container)
-        self.message_bar.clearWidgets()
-        self.search_status = False
-        self.toggle_search_buttons()
+            self.pagination_info_la.setText(tr("No results found"))
 
     def clear_search_results(self):
         self.scroll_area.setWidget(QtWidgets.QWidget())
-        self.resultsLabel.clear()
+        self.pagination_info_la.clear()
 
     def load_categories(self):
         self.category_cmb.addItems(

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -61,6 +61,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
     resource_types_btngrp: QtWidgets.QButtonGroup
     current_page: int = 0
     total_pages: int = 0
+    search_status: bool
 
     def __init__(self, parent, fl, widgetMode):
         super().__init__(parent, fl, widgetMode)
@@ -73,6 +74,8 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.connections_cmb.currentIndexChanged.connect(
             self.toggle_connection_management_buttons
         )
+
+        self.search_status = False
         self.connections_cmb.currentIndexChanged.connect(self.toggle_search_controls)
         self.update_connections_combobox()
         self.toggle_connection_management_buttons()
@@ -164,7 +167,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             if self.connections_cmb.currentText() != "":
                 for check_box in self.resource_types_btngrp.buttons():
                     if check_box.isChecked():
-                        enable_search = True
+                        enable_search = not self.search_status
                         enable_previous = self.current_page > 1
                         enable_next = self.current_page < self.total_pages
                         break
@@ -231,6 +234,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
 
     def search_geonode(self, reset_pagination: bool = False):
         self.clear_search_results()
+        self.search_status = True
         self.toggle_search_buttons(enable=False)
         self.show_progress(tr("Searching..."))
         connection_name = self.connections_cmb.currentText()
@@ -272,6 +276,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
 
     def show_search_error(self, error):
         self.message_bar.clearWidgets()
+        self.search_status = False
         self.toggle_search_buttons()
         network_error_enum = enum_mapping(
             QtNetwork.QNetworkReply, QtNetwork.QNetworkReply.NetworkError
@@ -299,6 +304,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
     ):
         self.current_page = pagination_info.current_page
         self.total_pages = pagination_info.total_pages
+        self.search_status = False
         self.toggle_search_buttons()
         if pagination_info.total_records > 0:
             self.resultsLabel.setText(
@@ -330,6 +336,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setWidget(scroll_container)
         self.message_bar.clearWidgets()
+        self.search_status = False
         self.toggle_search_buttons()
 
     def clear_search_results(self):

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -116,11 +116,16 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         )
         self.next_btn.clicked.connect(self.request_next_page)
         self.previous_btn.clicked.connect(self.request_previous_page)
+        self.grid_layout = QtWidgets.QGridLayout()
         self.message_bar = qgis.gui.QgsMessageBar()
         self.message_bar.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
         )
-        self.layout().insertWidget(4, self.message_bar)
+        self.grid_layout.addWidget(self.scroll_area, 0, 0, 1, 1)
+        self.grid_layout.addWidget(
+            self.message_bar, 0, 0, 1, 1, alignment=QtCore.Qt.AlignTop
+        )
+        self.layout().insertLayout(4, self.grid_layout)
 
         self.keyword_tool_btn.clicked.connect(self.search_keywords)
         self.toggle_search_buttons()

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -332,6 +332,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.message_bar.clearWidgets()
         self.toggle_search_buttons()
 
+
     def clear_search_results(self):
         self.scroll_area.setWidget(QtWidgets.QWidget())
         self.resultsLabel.clear()

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -300,7 +300,10 @@ class LayerLoaderTask(qgis.core.QgsTask):
 
     def finished(self, result: bool):
         if result:
-            self.layer_handler(self.layer)
+            # Cloning the layer seems to be required in order to make sure the WMS
+            # layers work appropriately
+            cloned_layer = self.layer.clone()
+            self.layer_handler(cloned_layer)
         else:
             message = f"Error loading layer {self.layer_uri!r}"
             log(message)

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -26,14 +26,13 @@ WidgetUi, _ = loadUiType(
 
 
 class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
-    name_la: QtWidgets.QLabel
-    description_la: QtWidgets.QLabel
-    resource_type_la: QtWidgets.QLabel
-    resource_type_icon_la: QtWidgets.QLabel
-    thumbnail_la: QtWidgets.QLabel
-    message_bar: qgis.gui.QgsMessageBar
     action_buttons_layout: QtWidgets.QHBoxLayout
     browser_btn: QtWidgets.QPushButton
+    description_la: QtWidgets.QLabel
+    name_la: QtWidgets.QLabel
+    resource_type_icon_la: QtWidgets.QLabel
+    resource_type_la: QtWidgets.QLabel
+    thumbnail_la: QtWidgets.QLabel
 
     layer_loader_task: typing.Optional[qgis.core.QgsTask]
     thumbnail_loader_task: typing.Optional[qgis.core.QgsTask]
@@ -41,23 +40,36 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
     load_layer_started = QtCore.pyqtSignal()
     load_layer_ended = QtCore.pyqtSignal()
 
+    api_client: BaseGeonodeClient
+    brief_resource: BriefGeonodeResource
+    full_resource: typing.Optional[GeonodeResource]
+    layer: typing.Optional["QgsMapLayer"]
+
     def __init__(
         self,
-        geonode_resource: BriefGeonodeResource,
+        brief_resource: BriefGeonodeResource,
         api_client: BaseGeonodeClient,
         parent=None,
     ):
         super().__init__(parent)
         self.setupUi(self)
+        self.project = qgis.core.QgsProject.instance()
         self.thumbnail_loader_task = None
         self.layer_loader_task = None
-        self.name_la.setText(f"<h3>{geonode_resource.name}</h3>")
+        self.layer = None
+        self.brief_resource = brief_resource
+        self.full_resource = None
+        self.api_client = api_client
+        self._initialize_ui()
+        self.toggle_service_url_buttons(True)
+        self.load_thumbnail()
 
-        name = api_client.get_search_result_identifier(geonode_resource)
+    def _initialize_ui(self):
+        name = self.api_client.get_search_result_identifier(self.brief_resource)
         self.name_la.setText(f"<h3>{name}</h3>")
 
-        if geonode_resource.resource_type is not None:
-            self.resource_type_la.setText(geonode_resource.resource_type.value)
+        if self.brief_resource.resource_type is not None:
+            self.resource_type_la.setText(self.brief_resource.resource_type.value)
             icon_path = {
                 GeonodeResourceType.RASTER_LAYER: (
                     ":/images/themes/default/mIconRaster.svg"
@@ -66,216 +78,44 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
                     ":/images/themes/default/mIconVector.svg"
                 ),
                 GeonodeResourceType.MAP: ":/images/themes/default/mIconRaster.svg",
-            }[geonode_resource.resource_type]
+            }[self.brief_resource.resource_type]
             self.resource_type_icon_la.setPixmap(QtGui.QPixmap(icon_path))
         else:
             self.resource_type_icon_la.setText("")
             self.resource_type_la.setText(tr("Unknown type"))
         sliced_abstract = (
-            f"{geonode_resource.abstract[:700]}..."
-            if len(geonode_resource.abstract) > 700
-            else geonode_resource.abstract
+            f"{self.brief_resource.abstract[:700]}..."
+            if len(self.brief_resource.abstract) > 700
+            else self.brief_resource.abstract
         )
-
         self.description_la.setText(sliced_abstract)
-        self.geonode_resource = geonode_resource
-        connection_settings = connections_manager.get_current_connection()
-        self.client = get_geonode_client(connection_settings)
+
         for service_type in GeonodeService:
-            url = geonode_resource.service_urls.get(service_type)
-            if url is not None:
-                (
-                    description,
-                    order,
-                    icon_path,
-                    handler,
-                ) = self._get_service_button_details(service_type)
-                icon = QtGui.QIcon(icon_path)
+            url = self.brief_resource.service_urls.get(service_type)
+            if url is not None and service_type != GeonodeService.FILE_DOWNLOAD:
+                icon = QtGui.QIcon(
+                    f":/plugins/qgis_geonode/icon_{service_type.value}.svg"
+                )
                 button = QtWidgets.QPushButton()
                 button.setObjectName(f"{service_type.name.lower()}_btn")
                 button.setIcon(icon)
-                button.setToolTip(tr("Load layer via {}").format(description))
-                button.clicked.connect(handler)
+                button.setToolTip(tr("Load layer via {}").format(service_type.value))
+                button.clicked.connect(partial(self.load_layer, service_type))
+                order = 1 if service_type == GeonodeService.OGC_WMS else 2
                 self.action_buttons_layout.insertWidget(order, button)
-
-        self.toggle_service_url_buttons(True)
-        self.load_thumbnail()
         self.browser_btn.setIcon(QtGui.QIcon(":/plugins/qgis_geonode/mIconGeonode.svg"))
         self.browser_btn.clicked.connect(self.open_resource_page)
 
-    def _get_service_button_details(
-        self, service: GeonodeService
-    ) -> typing.Tuple[str, int, str, typing.Callable]:
-        icon_path = f":/plugins/qgis_geonode/icon_{service.value}.svg"
-        return {
-            GeonodeService.OGC_WMS: (
-                "WMS",
-                1,
-                icon_path,
-                partial(self.load_layer, service),
-            ),
-            GeonodeService.OGC_WFS: (
-                "WFS",
-                2,
-                icon_path,
-                partial(self.load_layer, service),
-            ),
-            GeonodeService.OGC_WCS: (
-                "WCS",
-                2,
-                icon_path,
-                partial(self.load_layer, service),
-            ),
-            GeonodeService.FILE_DOWNLOAD: ("File download", 3, None, None),
-        }[service]
-
-    def get_datasource_widget(self):
-        return self.parent().parent().parent().parent()
-
-    def handle_layer_load_start(self):
-        parent = self.get_datasource_widget()
-        parent.toggle_search_controls(False)
-        parent.show_progress(tr("Loading layer..."))
-        self.toggle_service_url_buttons(False)
-
-    def handle_layer_load_end(self):
-        parent = self.get_datasource_widget()
-        parent.toggle_search_controls(True)
-        parent.toggle_search_buttons()
-        self.toggle_service_url_buttons(True)
-        self.clear_progress()
-
-    def handle_loading_error(self, message: str):
-        self.get_datasource_widget().show_message(
-            message, level=qgis.core.Qgis.Critical
-        )
-        self.toggle_service_url_buttons(True)
-
-    def load_layer(self, service_type: GeonodeService):
-        self.handle_layer_load_start()
-        self.client.error_received.connect(self.handle_loading_error)
-        self.layer_loader_task = LayerLoaderTask(
-            self.geonode_resource,
-            service_type,
-            api_client=self.client,
-            layer_handler=self.prepare_layer,
-            error_handler=self.handle_loading_error
-        )
-        qgis.core.QgsApplication.taskManager().addTask(self.layer_loader_task)
-
-    def handle_loading_error(
-            self, qt_error: str, http_status_code: int, http_status_reason: str):
-        if http_status_code != 0:
-            http_status = f"{http_status_code} - {http_status_reason}"
+    def open_resource_page(self):
+        if self.brief_resource.gui_url is not None:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl(self.brief_resource.gui_url))
         else:
-            http_status = ""
-        self.handle_layer_load_end()
-        message = " ".join((qt_error, http_status))
-        self.get_datasource_widget().show_message(message, level=qgis.core.Qgis.Critical)
-
-    def prepare_layer(self, layer: "QgsMapLayer", geonode_resource: GeonodeResource):
-        self.populate_metadata(layer, geonode_resource)
-        if layer.type() == qgis.core.QgsMapLayerType.VectorLayer:
-            self.client.style_detail_received.connect(
-                partial(self.load_sld_layer, layer)
+            message = (
+                "Couldn't open resource in browser page, the resource doesn't contain "
+                "GeoNode layer page URL"
             )
-            self.client.get_layer_style(geonode_resource)
-        else:  # TODO: add support for loading SLDs for raster layers too
-            self.add_layer_to_project(layer)
-
-    def add_layer_to_project(self, layer: "QgsMapLayer"):
-        self.client.layer_detail_received.disconnect()
-        self.client.error_received.disconnect()
-        try:
-            self.client.style_detail_received.disconnect()
-        except TypeError:
-            pass
-        qgis.core.QgsProject.instance().addMapLayer(layer)
-        self.handle_layer_load_end()
-
-    def populate_metadata(self, layer, geonode_resource):
-        metadata = layer.metadata()
-        metadata.setIdentifier(str(geonode_resource.uuid))
-        metadata.setTitle(geonode_resource.title)
-        metadata.setAbstract(geonode_resource.abstract)
-        metadata.setLanguage(geonode_resource.language)
-        metadata.setKeywords({"layer": geonode_resource.keywords})
-        if geonode_resource.category:
-            metadata.setCategories([geonode_resource.category])
-        if geonode_resource.license:
-            metadata.setLicenses([geonode_resource.license])
-        if geonode_resource.constraints:
-            constraints = [
-                qgis.core.QgsLayerMetadata.Constraint(geonode_resource.constraints)
-            ]
-            metadata.setConstraints(constraints)
-
-        metadata.setCrs(geonode_resource.crs)
-
-        spatial_extent = qgis.core.QgsLayerMetadata.SpatialExtent()
-        spatial_extent.extentCrs = geonode_resource.crs
-        if geonode_resource.spatial_extent:
-            spatial_extent.bounds = geonode_resource.spatial_extent.toBox3d(0, 0)
-            if geonode_resource.temporal_extent:
-                metadata.extent().setTemporalExtents(
-                    [
-                        qgis.core.QgsDateTimeRange(
-                            geonode_resource.temporal_extent[0],
-                            geonode_resource.temporal_extent[1],
-                        )
-                    ]
-                )
-
-        metadata.extent().setSpatialExtents([spatial_extent])
-
-        if geonode_resource.owner:
-            owner_contact = qgis.core.QgsAbstractMetadataBase.Contact(
-                geonode_resource.owner["username"]
-            )
-            owner_contact.role = tr("owner")
-            metadata.addContact(owner_contact)
-        if geonode_resource.metadata_author:
-            metadata_author = qgis.core.QgsAbstractMetadataBase.Contact(
-                geonode_resource.metadata_author["username"]
-            )
-            metadata_author.role = tr("metadata_author")
-            metadata.addContact(metadata_author)
-
-        links = []
-
-        if geonode_resource.thumbnail_url:
-            link = qgis.core.QgsAbstractMetadataBase.Link(
-                tr("Thumbnail"), tr("Thumbail_link"), geonode_resource.thumbnail_url
-            )
-            links.append(link)
-
-        if geonode_resource.api_url:
-            link = qgis.core.QgsAbstractMetadataBase.Link(
-                tr("API"), tr("API_URL"), geonode_resource.api_url
-            )
-            links.append(link)
-
-        if geonode_resource.gui_url:
-            link = qgis.core.QgsAbstractMetadataBase.Link(
-                tr("Detail"), tr("Detail_URL"), geonode_resource.gui_url
-            )
-            links.append(link)
-
-        metadata.setLinks(links)
-
-        layer.setMetadata(metadata)
-
-    def load_sld_layer(self, layer, sld_named_layer: QtXml.QDomElement):
-        """Retrieve SLD style and set it to the layer, then add layer to QGIS project"""
-        log(f"inside load_sld_layer...")
-        error_message = ""
-        loaded_sld = layer.readSld(sld_named_layer, error_message)
-        if not loaded_sld:
-            self.get_datasource_widget().show_message(
-                tr(f"Problem in applying GeoNode style for the layer: {error_message}")
-            )
-            # self.toggle_service_url_buttons(True)
-        self.add_layer_to_project(layer)
+            log(message)
+            self._get_datasource_widget().show_message(tr(message))
 
     def toggle_service_url_buttons(self, enabled: bool):
         for index in range(self.action_buttons_layout.count()):
@@ -285,9 +125,10 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
 
     def load_thumbnail(self):
         """Fetch the thumbnail from its remote URL and load it"""
-        request = QtCore.QUrl(self.geonode_resource.thumbnail_url)
         # TODO: do we need to provide auth config here?
-        task = qgis.core.QgsNetworkContentFetcherTask(request)
+        task = qgis.core.QgsNetworkContentFetcherTask(
+            QtCore.QUrl(self.brief_resource.thumbnail_url)
+        )
         task.fetched.connect(partial(self.handle_thumbnail_response, task))
         task.run()
 
@@ -299,25 +140,95 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
             self.thumbnail_loader_task = ThumbnailLoader(
                 contents,
                 self.thumbnail_la,
-                self.geonode_resource.title,
+                self.brief_resource.title,
             )
             qgis.core.QgsApplication.taskManager().addTask(self.thumbnail_loader_task)
         else:
             log(f"Error retrieving thumbnail for {self.geonode_resource.title}")
 
-    def open_resource_page(self):
-        if self.geonode_resource.gui_url is not None:
-            QtGui.QDesktopServices.openUrl(QtCore.QUrl(self.geonode_resource.gui_url))
-        else:
-            message = (
-                "Couldn't open resource in browser page, the resource doesn't contain "
-                "GeoNode layer page URL"
-            )
-            log(message)
-            self.get_datasource_widget().show_message(tr(message))
+    def _get_datasource_widget(self):
+        return self.parent().parent().parent().parent()
 
-    def clear_progress(self):
-        self.get_datasource_widget().message_bar.clearWidgets()
+    def handle_layer_load_start(self):
+        parent = self._get_datasource_widget()
+        parent.toggle_search_controls(False)
+        parent.show_progress(tr("Loading layer..."))
+        self.toggle_service_url_buttons(False)
+
+    def handle_layer_load_end(self):
+        parent = self._get_datasource_widget()
+        parent.toggle_search_controls(True)
+        parent.toggle_search_buttons()
+        self.toggle_service_url_buttons(True)
+        self._get_datasource_widget().message_bar.clearWidgets()
+
+    def handle_loading_error(
+        self, qt_error: str, http_status_code: int, http_status_reason: str
+    ):
+        if http_status_code != 0:
+            http_status = f"{http_status_code} - {http_status_reason}"
+        else:
+            http_status = ""
+        self.handle_layer_load_end()
+        message = " ".join((qt_error, http_status))
+        self._get_datasource_widget().show_message(
+            message, level=qgis.core.Qgis.Critical
+        )
+
+    def load_layer(self, service_type: GeonodeService):
+        self.handle_layer_load_start()
+        uri = self.brief_resource.service_urls[service_type]
+        self.layer_loader_task = LayerLoaderTask(
+            uri,
+            self.brief_resource.title,
+            service_type,
+            api_client=self.api_client,
+            layer_handler=self.prepare_loaded_layer,
+            error_handler=self.handle_loading_error,
+        )
+        qgis.core.QgsApplication.taskManager().addTask(self.layer_loader_task)
+
+    def prepare_loaded_layer(self, layer: "QgsMapLayer"):
+        """Retrieve layer details for the layer that has been loaded"""
+        self.layer = layer
+        self.api_client.layer_detail_received.connect(self.handle_layer_detail)
+        self.api_client.error_received.connect(self.handle_loading_error)
+        self.api_client.get_layer_detail_from_brief_resource(self.brief_resource)
+
+    def handle_layer_detail(self, resource: GeonodeResource):
+        """Populate the loaded layer with metadata from the retrived GeoNode resource
+
+        Then either retrieve the layer's SLD or add it to QGIS project
+
+        """
+
+        self.full_resource = resource
+        log("handle_layer_detail called")
+        self.api_client.layer_detail_received.disconnect(self.handle_layer_detail)
+        metadata = populate_metadata(self.layer.metadata(), resource)
+        self.layer.setMetadata(metadata)
+        if self.layer.type() == qgis.core.QgsMapLayer.VectorLayer:
+            self.api_client.style_detail_received.connect(self.handle_sld_received)
+            self.api_client.get_layer_style(self.full_resource)
+        else:  # TODO: add support for loading SLDs for raster layers too
+            self.add_layer_to_project()
+
+    def handle_sld_received(self, sld_named_layer: QtXml.QDomElement):
+        """Retrieve SLD style and set it to the layer, then add layer to QGIS project"""
+        self.api_client.style_detail_received.disconnect(self.handle_sld_received)
+        error_message = ""
+        loaded_sld = self.layer.readSld(sld_named_layer, error_message)
+        if not loaded_sld:
+            self._get_datasource_widget().show_message(
+                tr(f"Problem in applying GeoNode style for the layer: {error_message}")
+            )
+        self.add_layer_to_project()
+
+    def add_layer_to_project(self):
+        self.api_client.error_received.disconnect(self.handle_loading_error)
+        self.project.addMapLayer(self.layer)
+        # log("Pretend to add layer to QGIS")
+        self.handle_layer_load_end()
 
 
 class ThumbnailLoader(qgis.core.QgsTask):
@@ -347,7 +258,7 @@ class ThumbnailLoader(qgis.core.QgsTask):
 
 
 class LayerLoaderTask(qgis.core.QgsTask):
-    geonode_resource: BriefGeonodeResource
+    brief_resource: BriefGeonodeResource
     service_type: GeonodeService
     api_client: "BaseGeonodeClient"
     layer_handler: typing.Callable
@@ -355,15 +266,17 @@ class LayerLoaderTask(qgis.core.QgsTask):
     layer: typing.Optional["QgsMapLayer"]
 
     def __init__(
-            self,
-            geonode_resource: BriefGeonodeResource,
-            service_type: GeonodeService,
-            api_client: "BaseGeonodeClient",
-            layer_handler: typing.Callable,
-            error_handler: typing.Callable,
+        self,
+        uri: str,
+        layer_title: str,
+        service_type: GeonodeService,
+        api_client: "BaseGeonodeClient",
+        layer_handler: typing.Callable,
+        error_handler: typing.Callable,
     ):
         super().__init__()
-        self.geonode_resource = geonode_resource
+        self.uri = uri
+        self.layer_title = layer_title
         self.service_type = service_type
         self.api_client = api_client
         self.layer_handler = layer_handler
@@ -371,8 +284,7 @@ class LayerLoaderTask(qgis.core.QgsTask):
         self.layer = None
 
     def run(self):
-        uri = self.geonode_resource.service_urls[self.service_type]
-        log(f"service_uri: {uri}")
+        log(f"service_uri: {self.uri}")
         layer_class, provider = {
             GeonodeService.OGC_WMS: (qgis.core.QgsRasterLayer, "wms"),
             GeonodeService.OGC_WCS: (qgis.core.QgsRasterLayer, "wcs"),
@@ -381,18 +293,80 @@ class LayerLoaderTask(qgis.core.QgsTask):
                 "WFS",
             ),  # TODO: does this really require all caps?
         }[self.service_type]
-        layer = layer_class(uri, self.geonode_resource.title, provider)
+        layer = layer_class(self.uri, self.layer_title, provider)
         if layer.isValid():
             self.layer = layer
         return self.layer is not None
 
     def finished(self, result: bool):
         if result:
-            self.api_client.layer_detail_received.connect(
-                partial(self.layer_handler, self.layer)
-            )
-            self.api_client.get_layer_detail_from_brief_resource(self.geonode_resource)
+            self.layer_handler(self.layer)
         else:
             message = f"Error loading layer {self.layer_uri!r}"
             log(message)
             self.error_handler(message)
+
+
+def populate_metadata(
+    metadata: qgis.core.QgsLayerMetadata, geonode_resource: GeonodeResource
+):
+    metadata.setIdentifier(str(geonode_resource.uuid))
+    metadata.setTitle(geonode_resource.title)
+    metadata.setAbstract(geonode_resource.abstract)
+    metadata.setLanguage(geonode_resource.language)
+    metadata.setKeywords({"layer": geonode_resource.keywords})
+    if geonode_resource.category:
+        metadata.setCategories([geonode_resource.category])
+    if geonode_resource.license:
+        metadata.setLicenses([geonode_resource.license])
+    if geonode_resource.constraints:
+        constraints = [
+            qgis.core.QgsLayerMetadata.Constraint(geonode_resource.constraints)
+        ]
+        metadata.setConstraints(constraints)
+    metadata.setCrs(geonode_resource.crs)
+    spatial_extent = qgis.core.QgsLayerMetadata.SpatialExtent()
+    spatial_extent.extentCrs = geonode_resource.crs
+    if geonode_resource.spatial_extent:
+        spatial_extent.bounds = geonode_resource.spatial_extent.toBox3d(0, 0)
+        if geonode_resource.temporal_extent:
+            metadata.extent().setTemporalExtents(
+                [
+                    qgis.core.QgsDateTimeRange(
+                        geonode_resource.temporal_extent[0],
+                        geonode_resource.temporal_extent[1],
+                    )
+                ]
+            )
+
+    metadata.extent().setSpatialExtents([spatial_extent])
+    if geonode_resource.owner:
+        owner_contact = qgis.core.QgsAbstractMetadataBase.Contact(
+            geonode_resource.owner["username"]
+        )
+        owner_contact.role = tr("owner")
+        metadata.addContact(owner_contact)
+    if geonode_resource.metadata_author:
+        metadata_author = qgis.core.QgsAbstractMetadataBase.Contact(
+            geonode_resource.metadata_author["username"]
+        )
+        metadata_author.role = tr("metadata_author")
+        metadata.addContact(metadata_author)
+    links = []
+    if geonode_resource.thumbnail_url:
+        link = qgis.core.QgsAbstractMetadataBase.Link(
+            tr("Thumbnail"), tr("Thumbail_link"), geonode_resource.thumbnail_url
+        )
+        links.append(link)
+    if geonode_resource.api_url:
+        link = qgis.core.QgsAbstractMetadataBase.Link(
+            tr("API"), tr("API_URL"), geonode_resource.api_url
+        )
+        links.append(link)
+    if geonode_resource.gui_url:
+        link = qgis.core.QgsAbstractMetadataBase.Link(
+            tr("Detail"), tr("Detail_URL"), geonode_resource.gui_url
+        )
+        links.append(link)
+    metadata.setLinks(links)
+    return metadata

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -301,7 +301,9 @@ class LayerLoaderTask(qgis.core.QgsTask):
     def finished(self, result: bool):
         if result:
             # Cloning the layer seems to be required in order to make sure the WMS
-            # layers work appropriately
+            # layers work appropriately - Otherwise we get random crashes when loading
+            # WMS layers. This may be related to how the layer is moved from the
+            # secondary thread by QgsTaskManager and the layer's ownership.
             cloned_layer = self.layer.clone()
             self.layer_handler(cloned_layer)
         else:

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -118,6 +118,9 @@
           <property name="text">
            <string>Title</string>
           </property>
+          <property name="buddy">
+           <cstring>title_le</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -161,6 +164,9 @@
            <property name="text">
             <string>Abstract</string>
            </property>
+           <property name="buddy">
+            <cstring>abstract_le</cstring>
+           </property>
           </widget>
          </item>
          <item row="1" column="1">
@@ -177,6 +183,9 @@
            </property>
            <property name="text">
             <string>Keywords</string>
+           </property>
+           <property name="buddy">
+            <cstring>keyword_cmb</cstring>
            </property>
           </widget>
          </item>
@@ -205,6 +214,9 @@
            </property>
            <property name="text">
             <string>Topic Category</string>
+           </property>
+           <property name="buddy">
+            <cstring>category_cmb</cstring>
            </property>
           </widget>
          </item>
@@ -292,6 +304,9 @@
            <property name="text">
             <string>Start</string>
            </property>
+           <property name="buddy">
+            <cstring>start_dte</cstring>
+           </property>
           </widget>
          </item>
          <item row="5" column="1">
@@ -311,6 +326,9 @@
            </property>
            <property name="text">
             <string>End</string>
+           </property>
+           <property name="buddy">
+            <cstring>end_dte</cstring>
            </property>
           </widget>
          </item>
@@ -425,6 +443,9 @@
        <property name="text">
         <string>Search Geonode</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -472,6 +493,9 @@
        </property>
        <property name="text">
         <string>Sort by</string>
+       </property>
+       <property name="buddy">
+        <cstring>sort_field_cmb</cstring>
        </property>
       </widget>
      </item>
@@ -587,6 +611,33 @@
    <header>qgsdatetimeedit.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>title_le</tabstop>
+  <tabstop>abstract_le</tabstop>
+  <tabstop>keyword_cmb</tabstop>
+  <tabstop>keyword_tool_btn</tabstop>
+  <tabstop>category_cmb</tabstop>
+  <tabstop>vector_chb</tabstop>
+  <tabstop>raster_chb</tabstop>
+  <tabstop>map_chb</tabstop>
+  <tabstop>start_dte</tabstop>
+  <tabstop>end_dte</tabstop>
+  <tabstop>search_btn</tabstop>
+  <tabstop>previous_btn</tabstop>
+  <tabstop>next_btn</tabstop>
+  <tabstop>sort_field_cmb</tabstop>
+  <tabstop>reverse_order_chb</tabstop>
+  <tabstop>scroll_area</tabstop>
+  <tabstop>connections_cmb</tabstop>
+  <tabstop>new_connection_btn</tabstop>
+  <tabstop>edit_connection_btn</tabstop>
+  <tabstop>delete_connection_btn</tabstop>
+  <tabstop>load_connection_btn</tabstop>
+  <tabstop>save_connection_btn</tabstop>
+  <tabstop>comboBox_6</tabstop>
+  <tabstop>btnSave_3</tabstop>
+  <tabstop>btnLoad_3</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
  <buttongroups>

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -26,7 +26,7 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QPushButton" name="btnNew">
+         <widget class="QPushButton" name="new_connection_btn">
           <property name="toolTip">
            <string>Create a new service connection</string>
           </property>
@@ -36,7 +36,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btnEdit">
+         <widget class="QPushButton" name="edit_connection_btn">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -49,7 +49,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btnDelete">
+         <widget class="QPushButton" name="delete_connection_btn">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -78,7 +78,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="btnLoad">
+         <widget class="QPushButton" name="load_connection_btn">
           <property name="toolTip">
            <string>Load connections from file</string>
           </property>
@@ -88,7 +88,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btnSave_2">
+         <widget class="QPushButton" name="save_connection_btn">
           <property name="toolTip">
            <string>Save connections to file</string>
           </property>
@@ -492,7 +492,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="reverse_order_chk">
+      <widget class="QCheckBox" name="reverse_order_chb">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -525,7 +525,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="resultsLabel">
+      <widget class="QLabel" name="pagination_info_la">
        <property name="text">
         <string>Zero Results</string>
        </property>

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -40,19 +40,3 @@ def tr(text):
     if type(text) != str:
         text = str(text)
     return QCoreApplication.translate("QgisGeoNode", text)
-
-
-def enum_mapping(cls, enum):
-    """workaround for accessing unsubscriptable sip enum types
-
-    from https://stackoverflow.com/a/39677321
-
-    """
-
-    mapping = {}
-    for key in dir(cls):
-        value = getattr(cls, key)
-        if isinstance(value, enum):
-            mapping[key] = value
-            mapping[value] = key
-    return mapping


### PR DESCRIPTION
This PR implements:

1. A tighter control over the availability of search UI controls. Most UI controls are now disabled when a search or load operation is in course. This prevents the user from putting the UI in an invalid state
2. Improved error handling and reporting. Also, the message bar no longer causes the other widgets to jump around whenever it is shown/hidden
3. Asynchronous loading of GeoNode layers onto the QGIS canvas. These were previously being loaded in the same thread as the UI, which caused undesirable blocking. Layers are now loaded on a background thread, by leveraging QgsTask

fixes #138 
fixes #69 