### PR TITLE
Support for temporal filtering

### DIFF
--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -8,11 +8,8 @@ from qgis.core import (
     QgsDateTimeRange,
     QgsRectangle,
 )
-from qgis.PyQt.QtCore import (
-    QByteArray,
-    QUrl,
-    QUrlQuery,
-    Qt,
+from qgis.PyQt import (
+    QtCore,
 )
 
 from ..utils import log
@@ -57,10 +54,47 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         page_size: typing.Optional[int] = 10,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
-    ) -> QUrl:
-        url = QUrl(f"{self.api_url}/layers/")
-        query = QUrlQuery()
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
+    ) -> QtCore.QUrl:
+        url = QtCore.QUrl(f"{self.api_url}/layers/")
+        query = self._build_search_query(
+            page,
+            page_size,
+            title,
+            abstract,
+            keyword,
+            topic_category,
+            layer_types,
+            ordering_field,
+            reverse_ordering,
+            temporal_extent_start,
+            temporal_extent_end,
+            publication_date_start,
+            publication_date_end,
+        )
+        url.setQuery(query.query())
+        return url
+
+    def _build_search_query(
+        self,
+        page: int,
+        page_size: int,
+        title: typing.Optional[str] = None,
+        abstract: typing.Optional[str] = None,
+        keyword: typing.Optional[str] = None,
+        topic_category: typing.Optional[str] = None,
+        layer_types: typing.Optional[typing.Iterable[GeonodeResourceType]] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
+        reverse_ordering: typing.Optional[bool] = False,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
+    ) -> QtCore.QUrlQuery:
+        query = QtCore.QUrlQuery()
         query.addQueryItem("page", str(page))
         query.addQueryItem("page_size", str(page_size))
         if title is not None:
@@ -95,19 +129,31 @@ class GeonodeApiV2Client(BaseGeonodeClient):
                 ordering_field, reverse_sort=reverse_ordering
             )
             query.addQueryItem("sort[]", ordering_field_value)
-        if temporal_range is not None:
-            start = temporal_range.begin().toString(Qt.ISODate)
-            end = temporal_range.end().toString(Qt.ISODate)
-            query.addQueryItem("filter{date.gte}", start)
-            query.addQueryItem("filter{date.lt}", end)
-        url.setQuery(query.query())
-        return url
+        if temporal_extent_start is not None:
+            query.addQueryItem(
+                "filter{temporal_extent_start.gte}",
+                temporal_extent_start.toString(QtCore.Qt.ISODate),
+            )
+        if temporal_extent_end is not None:
+            query.addQueryItem(
+                "filter{temporal_extent_end.lte}",
+                temporal_extent_end.toString(QtCore.Qt.ISODate),
+            )
+        if publication_date_start is not None:
+            query.addQueryItem(
+                "filter{date.gte}", publication_date_start.toString(QtCore.Qt.ISODate)
+            )
+        if publication_date_end is not None:
+            query.addQueryItem(
+                "filter{date.lte}", publication_date_end.toString(QtCore.Qt.ISODate)
+            )
+        return query
 
-    def get_layer_detail_url_endpoint(self, id_: int) -> QUrl:
-        return QUrl(f"{self.api_url}/layers/{id_}/")
+    def get_layer_detail_url_endpoint(self, id_: int) -> QtCore.QUrl:
+        return QtCore.QUrl(f"{self.api_url}/layers/{id_}/")
 
     def get_layer_styles_url_endpoint(self, layer_id: int):
-        return QUrl(f"{self.api_url}/layers/{layer_id}/styles/")
+        return QtCore.QUrl(f"{self.api_url}/layers/{layer_id}/styles/")
 
     def get_maps_url_endpoint(
         self,
@@ -118,29 +164,25 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
-    ) -> QUrl:
-        url = QUrl(f"{self.api_url}/maps/")
-        query = QUrlQuery()
-        query.addQueryItem("page", str(page))
-        query.addQueryItem("page_size", str(page_size))
-        if title:
-            query.addQueryItem("filter{title.icontains}", title)
-        if keyword:  # TODO: Allow using multiple keywords
-            query.addQueryItem("filter{keywords.name.icontains}", keyword)
-        if topic_category:
-            query.addQueryItem("filter{category.identifier}", topic_category)
-
-        if ordering_field is not None:
-            ordering_field_value = self.get_ordering_filter_name(
-                ordering_field, reverse_sort=reverse_ordering
-            )
-            query.addQueryItem("sort[]", ordering_field_value)
-        if temporal_range is not None:
-            start = temporal_range.begin().toString(Qt.ISODate)
-            end = temporal_range.end().toString(Qt.ISODate)
-            query.addQueryItem("filter{date.gte}", start)
-            query.addQueryItem("filter{date.lt}", end)
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
+    ) -> QtCore.QUrl:
+        url = QtCore.QUrl(f"{self.api_url}/maps/")
+        query = self._build_search_query(
+            page,
+            page_size,
+            title,
+            keyword=keyword,
+            topic_category=topic_category,
+            ordering_field=ordering_field,
+            reverse_ordering=reverse_ordering,
+            temporal_extent_start=temporal_extent_start,
+            temporal_extent_end=temporal_extent_end,
+            publication_date_start=publication_date_start,
+            publication_date_end=publication_date_end,
+        )
         url.setQuery(query.query())
         return url
 
@@ -149,16 +191,21 @@ class GeonodeApiV2Client(BaseGeonodeClient):
     ):
         self.get_layer_detail(brief_resource.pk)
 
-    def deserialize_response_contents(self, contents: QByteArray) -> typing.Dict:
+    def deserialize_response_contents(self, contents: QtCore.QByteArray) -> typing.Dict:
         decoded_contents: str = contents.data().decode()
         return json.loads(decoded_contents)
 
     def handle_layer_list(self, payload: typing.Dict):
         layers = []
         for item in payload.get("layers", []):
-            layers.append(
-                get_brief_geonode_resource(item, self.base_url, self.auth_config)
-            )
+            try:
+                brief_resource = get_brief_geonode_resource(
+                    item, self.base_url, self.auth_config
+                )
+            except ValueError:
+                log(f"Could not parse {item!r} into a valid item")
+            else:
+                layers.append(brief_resource)
         pagination_info = models.GeoNodePaginationInfo(
             total_records=payload["total"],
             current_page=payload["page"],

--- a/src/qgis_geonode/apiclient/apiv2.py
+++ b/src/qgis_geonode/apiclient/apiv2.py
@@ -5,12 +5,14 @@ import uuid
 
 from qgis.core import (
     QgsCoordinateReferenceSystem,
+    QgsDateTimeRange,
     QgsRectangle,
 )
 from qgis.PyQt.QtCore import (
     QByteArray,
     QUrl,
     QUrlQuery,
+    Qt,
 )
 
 from ..utils import log
@@ -55,6 +57,7 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         page_size: typing.Optional[int] = 10,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
+        temporal_range: typing.Optional[QgsDateTimeRange] = None,
     ) -> QUrl:
         url = QUrl(f"{self.api_url}/layers/")
         query = QUrlQuery()
@@ -92,6 +95,11 @@ class GeonodeApiV2Client(BaseGeonodeClient):
                 ordering_field, reverse_sort=reverse_ordering
             )
             query.addQueryItem("sort[]", ordering_field_value)
+        if temporal_range is not None:
+            start = temporal_range.begin().toString(Qt.ISODate)
+            end = temporal_range.end().toString(Qt.ISODate)
+            query.addQueryItem("filter{date.gte}", start)
+            query.addQueryItem("filter{date.lt}", end)
         url.setQuery(query.query())
         return url
 
@@ -110,6 +118,7 @@ class GeonodeApiV2Client(BaseGeonodeClient):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
+        temporal_range: typing.Optional[QgsDateTimeRange] = None,
     ) -> QUrl:
         url = QUrl(f"{self.api_url}/maps/")
         query = QUrlQuery()
@@ -127,6 +136,11 @@ class GeonodeApiV2Client(BaseGeonodeClient):
                 ordering_field, reverse_sort=reverse_ordering
             )
             query.addQueryItem("sort[]", ordering_field_value)
+        if temporal_range is not None:
+            start = temporal_range.begin().toString(Qt.ISODate)
+            end = temporal_range.end().toString(Qt.ISODate)
+            query.addQueryItem("filter{date.gte}", start)
+            query.addQueryItem("filter{date.lt}", end)
         url.setQuery(query.query())
         return url
 

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -3,6 +3,7 @@ import uuid
 from functools import partial
 
 from qgis.core import (
+    QgsDateTimeRange,
     QgsMessageLog,
     QgsNetworkContentFetcherTask,
 )
@@ -64,7 +65,8 @@ class BaseGeonodeClient(QtCore.QObject):
         layer_type: typing.Optional[models.GeonodeResourceType] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-    ) -> QtCore.QUrl:
+        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+    ) -> QUrl:
         raise NotImplementedError
 
     def get_layer_detail_url_endpoint(
@@ -84,6 +86,7 @@ class BaseGeonodeClient(QtCore.QObject):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
+        temporal_range: typing.Optional[QgsDateTimeRange] = None,
     ) -> QtCore.QUrl:
         raise NotImplementedError
 
@@ -132,6 +135,7 @@ class BaseGeonodeClient(QtCore.QObject):
         page_size: typing.Optional[int] = 10,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
+        temporal_range: typing.Optional[QgsDateTimeRange] = None,
     ):
         url = self.get_layers_url_endpoint(
             title=title,
@@ -143,6 +147,7 @@ class BaseGeonodeClient(QtCore.QObject):
             page_size=page_size,
             ordering_field=ordering_field,
             reverse_ordering=reverse_ordering,
+            temporal_range=temporal_range,
         )
         request = QtNetwork.QNetworkRequest(url)
         self.run_task(request, self.handle_layer_list)
@@ -186,6 +191,7 @@ class BaseGeonodeClient(QtCore.QObject):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
+        temporal_range: typing.Optional[QgsDateTimeRange] = None,
     ):
         url = self.get_maps_url_endpoint(
             page=page,
@@ -195,6 +201,7 @@ class BaseGeonodeClient(QtCore.QObject):
             topic_category=topic_category,
             ordering_field=ordering_field,
             reverse_ordering=reverse_ordering,
+            temporal_range=temporal_range,
         )
         request = QtNetwork.QNetworkRequest(url)
         self.run_task(request, self.handle_map_list)

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -62,10 +62,13 @@ class BaseGeonodeClient(QtCore.QObject):
         abstract: typing.Optional[str] = None,
         keyword: typing.Optional[str] = None,
         topic_category: typing.Optional[str] = None,
-        layer_type: typing.Optional[models.GeonodeResourceType] = None,
+        layer_types: typing.Optional[models.GeonodeResourceType] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
     ) -> QtCore.QUrl:
         raise NotImplementedError
 
@@ -86,7 +89,10 @@ class BaseGeonodeClient(QtCore.QObject):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
     ) -> QtCore.QUrl:
         raise NotImplementedError
 
@@ -135,21 +141,28 @@ class BaseGeonodeClient(QtCore.QObject):
         page_size: typing.Optional[int] = 10,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
     ):
         url = self.get_layers_url_endpoint(
+            page=page,
+            page_size=page_size,
             title=title,
             abstract=abstract,
             keyword=keyword,
             topic_category=topic_category,
             layer_types=layer_types,
-            page=page,
-            page_size=page_size,
             ordering_field=ordering_field,
             reverse_ordering=reverse_ordering,
-            temporal_range=temporal_range,
+            temporal_extent_start=temporal_extent_start,
+            temporal_extent_end=temporal_extent_end,
+            publication_date_start=publication_date_start,
+            publication_date_end=publication_date_end,
         )
         request = QtNetwork.QNetworkRequest(url)
+        log(f"URL: {url.toString()}")
         self.run_task(request, self.handle_layer_list)
 
     def get_layer_detail_from_brief_resource(
@@ -191,7 +204,10 @@ class BaseGeonodeClient(QtCore.QObject):
         topic_category: typing.Optional[str] = None,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
     ):
         url = self.get_maps_url_endpoint(
             page=page,
@@ -201,7 +217,10 @@ class BaseGeonodeClient(QtCore.QObject):
             topic_category=topic_category,
             ordering_field=ordering_field,
             reverse_ordering=reverse_ordering,
-            temporal_range=temporal_range,
+            temporal_extent_start=temporal_extent_start,
+            temporal_extent_end=temporal_extent_end,
+            publication_date_start=publication_date_start,
+            publication_date_end=publication_date_end,
         )
         request = QtNetwork.QNetworkRequest(url)
         self.run_task(request, self.handle_map_list)

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -66,7 +66,7 @@ class BaseGeonodeClient(QtCore.QObject):
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
         temporal_range: typing.Optional[QgsDateTimeRange] = None,
-    ) -> QUrl:
+    ) -> QtCore.QUrl:
         raise NotImplementedError
 
     def get_layer_detail_url_endpoint(

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -149,7 +149,7 @@ class GeonodeCswClient(BaseGeonodeClient):
             query.addQueryItem("sortby", ordering_value)
         if temporal_range is not None:
             temporal_filter = _get_temporal_filter(temporal_range)
-            query.addQueryItem("constraintlanguage", "FILTER")
+            query.addQueryItem("constraintlanguage", "CQL_TEXT")
             query.addQueryItem("constraint", temporal_filter)
 
         # if any((title, abstract, keyword, topic_category, layer_types)):
@@ -755,19 +755,4 @@ def _get_temporal_filter(temporal_range: QgsDateTimeRange):
     start = temporal_range.begin().toString(QtCore.Qt.ISODate)
     end = temporal_range.end().toString(QtCore.Qt.ISODate)
 
-    return (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<ogc:Filter xmlns:gml="http://www.opengis.net/gml"'
-        'xmlns:ogc="http://www.opengis.net/ogc">'
-        "<ogc:And>"
-        "<ogc:PropertyIsGreaterThanOrEqualTo>"
-        "<ogc:PropertyName>TempExtent_begin</ogc:PropertyName>"
-        "<ogc:Literal>{}</ogc:Literal>"
-        "</ogc:PropertyIsGreaterThanOrEqualTo>"
-        "<ogc:PropertyIsLessThan>"
-        "<ogc:PropertyName>TempExtent_end</ogc:PropertyName>"
-        "<ogc:Literal>{}/ogc:Literal>"
-        "</ogc:PropertyIsLessThanOrEqualTo>"
-        "</ogc:And>"
-        "</ogc:Filter>".format(start, end)
-    )
+    return "dc:date >= '{}' and " "dc:date < '{}' ".format(start, end)

--- a/src/qgis_geonode/apiclient/csw.py
+++ b/src/qgis_geonode/apiclient/csw.py
@@ -1,4 +1,3 @@
-import dataclasses
 import datetime as dt
 import enum
 import json
@@ -23,7 +22,6 @@ from qgis.PyQt import (
     QtNetwork,
 )
 
-from ..utils import log
 from . import models
 from .base import BaseGeonodeClient
 from .models import GeonodeService
@@ -128,9 +126,49 @@ class GeonodeCswClient(BaseGeonodeClient):
         page_size: typing.Optional[int] = 10,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
     ) -> QtCore.QUrl:
         url = QtCore.QUrl(f"{self.catalogue_url}")
+        query = self._build_search_query(
+            page,
+            page_size,
+            title,
+            abstract,
+            keyword,
+            topic_category,
+            layer_types,
+            ordering_field,
+            reverse_ordering,
+            temporal_extent_start,
+            temporal_extent_end,
+            publication_date_start,
+            publication_date_end,
+        )
+        url.setQuery(query.query())
+        return url
+
+    def _build_search_query(
+        self,
+        page: int,
+        page_size: int,
+        title: typing.Optional[str] = None,
+        abstract: typing.Optional[str] = None,
+        keyword: typing.Optional[str] = None,
+        topic_category: typing.Optional[str] = None,
+        layer_types: typing.Optional[
+            typing.Iterable[models.GeonodeResourceType]
+        ] = None,
+        ordering_field: typing.Optional[models.OrderingType] = None,
+        reverse_ordering: typing.Optional[bool] = False,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
+    ) -> QtCore.QUrlQuery:
+        # FIXME: Add support for filtering with the other parameters
         query = QtCore.QUrlQuery()
         query.addQueryItem("service", "CSW")
         query.addQueryItem("version", "2.0.2")
@@ -141,26 +179,66 @@ class GeonodeCswClient(BaseGeonodeClient):
         query.addQueryItem("typenames", self.TYPE_NAME)
         query.addQueryItem("outputschema", self.OUTPUT_SCHEMA)
         query.addQueryItem("elementsetname", "full")
-
         if ordering_field is not None:
             ordering_value = self.get_ordering_filter_name(
                 ordering_field, reverse_ordering
             )
             query.addQueryItem("sortby", ordering_value)
-        if temporal_range is not None:
-            temporal_filter = _get_temporal_filter(temporal_range)
-            query.addQueryItem("constraintlanguage", "CQL_TEXT")
-            query.addQueryItem("constraint", temporal_filter)
-
-        # if any((title, abstract, keyword, topic_category, layer_types)):
-        #     query.addQueryItem("constraintlanguage", "CQL_TEXT")
-        #     constraint_values = []
-        #     if title is not None:
-        #         constraint_values.append(f"dc:title like '{title}'")
-        #     # FIXME: Add support for filtering with the other parameters
-        #     query.addQueryItem("constraint", " AND ".join(constraint_values))
-        url.setQuery(query.query())
-        return url
+        if layer_types is None:
+            types = [
+                models.GeonodeResourceType.VECTOR_LAYER,
+                models.GeonodeResourceType.RASTER_LAYER,
+                models.GeonodeResourceType.MAP,
+            ]
+        else:
+            types = list(layer_types)
+        cql_filter_params = (
+            title,
+            abstract,
+            keyword,
+            topic_category,
+            types,
+            temporal_extent_start,
+            temporal_extent_end,
+            publication_date_start,
+            publication_date_end,
+        )
+        if any(cql_filter_params):
+            constraint_parts = []
+            if title is not None:
+                constraint_parts.append(f"dc:title like '%{title}%'")
+                pass
+            if abstract is not None:
+                pass
+            if keyword is not None:
+                pass
+            if topic_category is not None:
+                pass
+            if types is not None:
+                pass
+            if temporal_extent_start is not None:
+                constraint_parts.append(
+                    f"apiso:TempExtent_begin >= "
+                    f"{temporal_extent_start.toString(QtCore.Qt.ISODate)}"
+                )
+            if temporal_extent_end is not None:
+                constraint_parts.append(
+                    f"apiso:TempExtent_end <= "
+                    f"{temporal_extent_end.toString(QtCore.Qt.ISODate)}"
+                )
+            if publication_date_start is not None:
+                constraint_parts.append(
+                    f"dc:date >= {publication_date_start.toString(QtCore.Qt.ISODate)}"
+                )
+            if publication_date_end is not None:
+                constraint_parts.append(
+                    f"dc:date <= {publication_date_end.toString(QtCore.Qt.ISODate)}"
+                )
+            query_param = " AND ".join(constraint_parts)
+            if query_param != "":
+                query.addQueryItem("constraintlanguage", "CQL_TEXT")
+                query.addQueryItem("constraint", " AND ".join(constraint_parts))
+        return query
 
     def get_layer_detail_from_brief_resource(
         self, brief_resource: models.BriefGeonodeResource
@@ -218,7 +296,10 @@ class GeonodeCswClient(BaseGeonodeClient):
         page_size: typing.Optional[int] = 10,
         ordering_field: typing.Optional[models.OrderingType] = None,
         reverse_ordering: typing.Optional[bool] = False,
-        temporal_range: typing.Optional[QgsDateTimeRange] = None,
+        temporal_extent_start: typing.Optional[QtCore.QDateTime] = None,
+        temporal_extent_end: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_start: typing.Optional[QtCore.QDateTime] = None,
+        publication_date_end: typing.Optional[QtCore.QDateTime] = None,
     ):
         """Get layers from the CSW endpoint
 
@@ -258,12 +339,14 @@ class GeonodeCswClient(BaseGeonodeClient):
             page_size,
             ordering_field,
             reverse_ordering,
-            temporal_range,
+            temporal_extent_start,
+            temporal_extent_end,
+            publication_date_start,
+            publication_date_end,
         )
 
     def deserialize_response_contents(self, contents: QtCore.QByteArray) -> ET.Element:
         decoded_contents: str = contents.data().decode()
-        log(f"decoded_contents: {decoded_contents}")
         return ET.fromstring(decoded_contents)
 
     def handle_layer_list(self, payload: ET.Element):
@@ -280,9 +363,14 @@ class GeonodeCswClient(BaseGeonodeClient):
                 f"{{{Csw202Namespace.GMD.value}}}MD_Metadata"
             )
             for item in items:
-                layers.append(
-                    get_brief_geonode_resource(item, self.base_url, self.auth_config)
-                )
+                try:
+                    brief_resource = get_brief_geonode_resource(
+                        item, self.base_url, self.auth_config
+                    )
+                except (AttributeError, ValueError):
+                    log(f"Could not parse {item!r} into a valid item")
+                else:
+                    layers.append(brief_resource)
             pagination_info = models.GeoNodePaginationInfo(
                 total_records=total, current_page=current_page, page_size=self.PAGE_SIZE
             )
@@ -749,10 +837,3 @@ def _get_wfs_uri(
     if auth_config is not None:
         params["authcfg"] = auth_config
     return " ".join(f"{k}='{v}'" for k, v in params.items())
-
-
-def _get_temporal_filter(temporal_range: QgsDateTimeRange):
-    start = temporal_range.begin().toString(QtCore.Qt.ISODate)
-    end = temporal_range.end().toString(QtCore.Qt.ISODate)
-
-    return "dc:date >= '{}' and " "dc:date < '{}' ".format(start, end)

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -306,8 +306,11 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             if search_map:
                 resource_types.append(models.GeonodeResourceType.MAP)
             # FIXME: Implement these as search filters
-            start = self.start_dte.dateTime()
-            end = self.end_dte.dateTime()
+            temporal_range = None
+            if not self.start_dte.isNull() and not self.end_dte.isNull():
+                temporal_range = qgis.core.QgsDateTimeRange(
+                    self.start_dte.dateTime(), self.end_dte.dateTime()
+                )
             if reset_pagination:
                 self.current_page = 1
                 self.total_pages = 1
@@ -320,7 +323,8 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
                 topic_category=self.category_cmb.currentText().lower() or None,
                 layer_types=resource_types,
                 ordering_field=self.sort_field_cmb.currentData(QtCore.Qt.UserRole),
-                reverse_ordering=self.reverse_order_chb.isChecked(),
+                reverse_ordering=self.reverse_order_chk.isChecked(),
+                temporal_range=temporal_range,
             )
 
     def toggle_search_controls(self, enabled: bool):

--- a/src/qgis_geonode/gui/geonode_source_select_provider.py
+++ b/src/qgis_geonode/gui/geonode_source_select_provider.py
@@ -55,7 +55,6 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
     connections_cmb: QtWidgets.QComboBox
     current_page: int = 0
     edit_connection_btn: QtWidgets.QPushButton
-    end_dte: qgis.gui.QgsDateTimeEdit
     delete_connection_btn: QtWidgets.QPushButton
     keyword_cmb: QtWidgets.QComboBox
     keyword_tool_btn: QtWidgets.QToolButton
@@ -66,6 +65,8 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
     new_connection_btn: QtWidgets.QPushButton
     pagination_info_la: QtWidgets.QLabel
     previous_btn: QtWidgets.QPushButton
+    publication_start_dte: qgis.gui.QgsDateTimeEdit
+    publication_end_dte: qgis.gui.QgsDateTimeEdit
     raster_chb: QtWidgets.QCheckBox
     resource_types_btngrp: QtWidgets.QButtonGroup
     reverse_order_chb: QtWidgets.QCheckBox
@@ -73,7 +74,8 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
     scroll_area: QtWidgets.QScrollArea
     search_btn: QtWidgets.QPushButton
     sort_field_cmb: QtWidgets.QComboBox
-    start_dte: qgis.gui.QgsDateTimeEdit
+    temporal_extent_start_dte: qgis.gui.QgsDateTimeEdit
+    temporal_extent_end_dte: qgis.gui.QgsDateTimeEdit
     title_le: QtWidgets.QLineEdit
     total_pages: int = 0
     vector_chb: QtWidgets.QCheckBox
@@ -129,8 +131,10 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
 
         self.keyword_tool_btn.clicked.connect(self.search_keywords)
         self.toggle_search_buttons()
-        self.start_dte.clear()
-        self.end_dte.clear()
+        self.temporal_extent_start_dte.clear()
+        self.temporal_extent_end_dte.clear()
+        self.publication_start_dte.clear()
+        self.publication_end_dte.clear()
         self.load_categories()
         self.load_sorting_fields(selected_by_default=models.OrderingType.NAME)
 
@@ -152,8 +156,10 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             self.vector_chb,
             self.raster_chb,
             self.map_chb,
-            self.start_dte,
-            self.end_dte,
+            self.temporal_extent_start_dte,
+            self.temporal_extent_end_dte,
+            self.publication_start_dte,
+            self.publication_end_dte,
             self.search_btn,
             self.next_btn,
             self.previous_btn,
@@ -306,14 +312,13 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             if search_map:
                 resource_types.append(models.GeonodeResourceType.MAP)
             # FIXME: Implement these as search filters
-            temporal_range = None
-            if not self.start_dte.isNull() and not self.end_dte.isNull():
-                temporal_range = qgis.core.QgsDateTimeRange(
-                    self.start_dte.dateTime(), self.end_dte.dateTime()
-                )
             if reset_pagination:
                 self.current_page = 1
                 self.total_pages = 1
+            extent_start = self.temporal_extent_start_dte.dateTime()
+            extent_end = self.temporal_extent_end_dte.dateTime()
+            pub_start = self.publication_start_dte.dateTime()
+            pub_end = self.publication_end_dte.dateTime()
             client.get_layers(
                 page=self.current_page,
                 page_size=connection_settings.page_size,
@@ -323,8 +328,13 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
                 topic_category=self.category_cmb.currentText().lower() or None,
                 layer_types=resource_types,
                 ordering_field=self.sort_field_cmb.currentData(QtCore.Qt.UserRole),
-                reverse_ordering=self.reverse_order_chk.isChecked(),
-                temporal_range=temporal_range,
+                reverse_ordering=self.reverse_order_chb.isChecked(),
+                temporal_extent_start=(
+                    extent_start if not extent_start.isNull() else None
+                ),
+                temporal_extent_end=extent_end if not extent_end.isNull() else None,
+                publication_date_start=pub_start if not pub_start.isNull() else None,
+                publication_date_end=pub_end if not pub_end.isNull() else None,
             )
 
     def toggle_search_controls(self, enabled: bool):

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -144,7 +144,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
             )
             qgis.core.QgsApplication.taskManager().addTask(self.thumbnail_loader_task)
         else:
-            log(f"Error retrieving thumbnail for {self.geonode_resource.title}")
+            log(f"Error retrieving thumbnail for {self.brief_resource.title}")
 
     def _get_datasource_widget(self):
         return self.parent().parent().parent().parent()

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -301,6 +301,9 @@
            <property name="enabled">
             <bool>true</bool>
            </property>
+           <property name="toolTip">
+            <string>Start datetime (inclusive)</string>
+           </property>
            <property name="text">
             <string>Start</string>
            </property>
@@ -323,6 +326,9 @@
           <widget class="QLabel" name="label_6">
            <property name="enabled">
             <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string>End datetime (not inclusive)</string>
            </property>
            <property name="text">
             <string>End</string>

--- a/src/qgis_geonode/ui/geonode_datasource_widget.ui
+++ b/src/qgis_geonode/ui/geonode_datasource_widget.ui
@@ -155,8 +155,8 @@
         <property name="collapsed">
          <bool>false</bool>
         </property>
-        <layout class="QFormLayout" name="formLayout">
-         <item row="1" column="0">
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="0" column="0">
           <widget class="QLabel" name="label_8">
            <property name="enabled">
             <bool>true</bool>
@@ -169,14 +169,14 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="0" column="1">
           <widget class="QLineEdit" name="abstract_le">
            <property name="enabled">
             <bool>true</bool>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
           <widget class="QLabel" name="label_3">
            <property name="enabled">
             <bool>true</bool>
@@ -189,7 +189,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="1" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
             <widget class="QComboBox" name="keyword_cmb">
@@ -207,7 +207,7 @@
            </item>
           </layout>
          </item>
-         <item row="3" column="0">
+         <item row="2" column="0">
           <widget class="QLabel" name="label_2">
            <property name="enabled">
             <bool>true</bool>
@@ -220,14 +220,14 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="2" column="1">
           <widget class="QComboBox" name="category_cmb">
            <property name="enabled">
             <bool>true</bool>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="label_5">
            <property name="enabled">
             <bool>true</bool>
@@ -240,7 +240,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="3" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QCheckBox" name="vector_chb">
@@ -296,56 +296,82 @@
            </item>
           </layout>
          </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="enabled">
+         <item row="4" column="0" colspan="2">
+          <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+           <property name="title">
+            <string>Temporal extent</string>
+           </property>
+           <property name="collapsed">
             <bool>true</bool>
            </property>
-           <property name="toolTip">
-            <string>Start datetime (inclusive)</string>
-           </property>
-           <property name="text">
-            <string>Start</string>
-           </property>
-           <property name="buddy">
-            <cstring>start_dte</cstring>
-           </property>
+           <layout class="QFormLayout" name="formLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_10">
+              <property name="text">
+               <string>Start</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QgsDateTimeEdit" name="temporal_extent_start_dte">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="allowNull">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>End</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QgsDateTimeEdit" name="temporal_extent_end_dte">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
-         <item row="5" column="1">
-          <widget class="QgsDateTimeEdit" name="start_dte">
-           <property name="enabled">
+         <item row="5" column="0" colspan="2">
+          <widget class="QgsCollapsibleGroupBox" name="mGroupBox_3">
+           <property name="title">
+            <string>Publication date</string>
+           </property>
+           <property name="collapsed">
             <bool>true</bool>
            </property>
-           <property name="allowNull">
-            <bool>true</bool>
-           </property>
+           <layout class="QFormLayout" name="formLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_12">
+              <property name="text">
+               <string>Start</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QgsDateTimeEdit" name="publication_start_dte"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_13">
+              <property name="text">
+               <string>End</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QgsDateTimeEdit" name="publication_end_dte"/>
+            </item>
+           </layout>
           </widget>
          </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="toolTip">
-            <string>End datetime (not inclusive)</string>
-           </property>
-           <property name="text">
-            <string>End</string>
-           </property>
-           <property name="buddy">
-            <cstring>end_dte</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="QgsDateTimeEdit" name="end_dte">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0" colspan="2">
+         <item row="6" column="0" colspan="2">
           <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
            <property name="enabled">
             <bool>false</bool>
@@ -586,7 +612,7 @@
         <x>0</x>
         <y>0</y>
         <width>708</width>
-        <height>122</height>
+        <height>152</height>
        </rect>
       </property>
      </widget>
@@ -626,8 +652,8 @@
   <tabstop>vector_chb</tabstop>
   <tabstop>raster_chb</tabstop>
   <tabstop>map_chb</tabstop>
-  <tabstop>start_dte</tabstop>
-  <tabstop>end_dte</tabstop>
+  <tabstop>temporal_extent_start_dte</tabstop>
+  <tabstop>temporal_extent_end_dte</tabstop>
   <tabstop>search_btn</tabstop>
   <tabstop>previous_btn</tabstop>
   <tabstop>next_btn</tabstop>


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/123

Using start and end datetime inputs in the search group box, this PR adds support for temporal filtering using those inputs.
The filtering use a range that include a start datetime and doesn't include the end datetime. The API uses 'date' field (store timestamp of when the resource was created) field to filter resources.

![temporal_filtering_apiv2](https://user-images.githubusercontent.com/2663775/110792799-e4273200-8284-11eb-91d9-48ecc0c0175d.gif)
