### PR TITLE
Add progress message when testing connection

### DIFF
--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -52,6 +52,9 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self._widgets_to_toggle_during_connection_test = [
             self.test_connection_btn,
             self.buttonBox,
+            self.authcfg_acs,
+            self.options_gb,
+            self.connection_details,
         ]
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -130,7 +130,10 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
 
     def test_connection(self):
         for widget in self._widgets_to_toggle_during_connection_test:
-            widget.setEnabled(False)
+            try:
+                widget.setEnabled(False)
+            except RuntimeError:
+                pass
         client = get_geonode_client(self.get_connection_settings())
         client.layer_list_received.connect(self.handle_connection_test_success)
         client.error_received.connect(self.handle_connection_test_error)
@@ -149,7 +152,10 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
 
     def enable_post_test_connection_buttons(self):
         for widget in self._widgets_to_toggle_during_connection_test:
-            widget.setEnabled(True)
+            try:
+                widget.setEnabled(True)
+            except RuntimeError:
+                pass
         self.update_ok_buttons()
 
     def initiate_api_version_detection(self):

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -57,7 +57,19 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self.bar.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
         )
-        self.layout().addWidget(self.bar, 0, 0, alignment=QtCore.Qt.AlignTop)
+        self.grid_layout.addWidget(self.bar, 0, 0, 1, 2, alignment=QtCore.Qt.AlignTop)
+        self.grid_layout.addWidget(
+            self.name_label, 1, 0, 1, 1, alignment=QtCore.Qt.AlignTop
+        )
+        self.grid_layout.addWidget(
+            self.name_le, 1, 1, 1, 1, alignment=QtCore.Qt.AlignTop
+        )
+        self.grid_layout.addWidget(
+            self.url_label, 2, 0, 1, 1, alignment=QtCore.Qt.AlignTop
+        )
+        self.grid_layout.addWidget(
+            self.url_le, 2, 1, 1, 1, alignment=QtCore.Qt.AlignTop
+        )
 
         self.api_version_cmb.currentTextChanged.connect(
             self.toggle_api_version_specific_widgets

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -57,19 +57,7 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self.bar.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
         )
-        self.grid_layout.addWidget(self.bar, 0, 0, 1, 2, alignment=QtCore.Qt.AlignTop)
-        self.grid_layout.addWidget(
-            self.name_label, 1, 0, 1, 1, alignment=QtCore.Qt.AlignTop
-        )
-        self.grid_layout.addWidget(
-            self.name_le, 1, 1, 1, 1, alignment=QtCore.Qt.AlignTop
-        )
-        self.grid_layout.addWidget(
-            self.url_label, 2, 0, 1, 1, alignment=QtCore.Qt.AlignTop
-        )
-        self.grid_layout.addWidget(
-            self.url_le, 2, 1, 1, 1, alignment=QtCore.Qt.AlignTop
-        )
+        self.layout().addWidget(self.bar, 0, 0, alignment=QtCore.Qt.AlignTop)
 
         self.api_version_cmb.currentTextChanged.connect(
             self.toggle_api_version_specific_widgets

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -24,7 +24,7 @@ from ..conf import (
     connections_manager,
     get_api_version_settings_handler,
 )
-from ..utils import log
+from ..utils import log, tr
 
 DialogUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/connection_dialog.ui")
@@ -131,12 +131,15 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         client.error_received.connect(self.handle_connection_test_error)
         client.layer_list_received.connect(self.enable_post_test_connection_buttons)
         client.error_received.connect(self.enable_post_test_connection_buttons)
+        self.show_progress(tr("Testing connection..."))
         client.get_layers()
 
     def handle_connection_test_success(self, payload: typing.Union[typing.Dict, int]):
+        self.bar.clearWidgets()
         self.bar.pushMessage("Connection is valid", level=Qgis.Info)
 
     def handle_connection_test_error(self, payload: typing.Union[typing.Dict, int]):
+        self.bar.clearWidgets()
         self.bar.pushMessage("Connection is not valid", level=Qgis.Critical)
 
     def enable_post_test_connection_buttons(self):
@@ -197,6 +200,15 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         enabled_state = self.name_le.text() != "" and self.url_le.text() != ""
         self.buttonBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enabled_state)
         self.test_connection_btn.setEnabled(enabled_state)
+
+    def show_progress(self, message):
+        message_bar_item = self.bar.createMessage(message)
+        progress_bar = QtWidgets.QProgressBar()
+        progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+        progress_bar.setMinimum(0)
+        progress_bar.setMaximum(0)
+        message_bar_item.layout().addWidget(progress_bar)
+        self.bar.pushWidget(message_bar_item, Qgis.Info)
 
 
 def _clear_layout(layout: QtWidgets.QLayout):

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -100,6 +100,7 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
             )
             layout: QtWidgets.QBoxLayout = self.layout()
             layout.addWidget(group_box, 3, 0, alignment=QtCore.Qt.AlignTop)
+            self._widgets_to_toggle_during_connection_test.append(group_box)
 
     def load_connection_settings(self, connection_settings: ConnectionSettings):
         self.name_le.setText(connection_settings.name)

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -57,7 +57,8 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self.bar.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
         )
-        self.layout().insertWidget(0, self.bar)
+        self.layout().addWidget(self.bar, 0, 0, alignment=QtCore.Qt.AlignTop)
+
         self.api_version_cmb.currentTextChanged.connect(
             self.toggle_api_version_specific_widgets
         )
@@ -95,7 +96,7 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
                 box_name, title=f"{api_version.name} version specific settings"
             )
             layout: QtWidgets.QBoxLayout = self.layout()
-            layout.insertWidget(4, group_box)
+            layout.addWidget(group_box, 3, 0, alignment=QtCore.Qt.AlignTop)
 
     def load_connection_settings(self, connection_settings: ConnectionSettings):
         self.name_le.setText(connection_settings.name)

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -7,54 +7,27 @@
     <x>0</x>
     <y>0</y>
     <width>596</width>
-    <height>311</height>
+    <height>313</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>GeoNode Connection Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="0" column="0">
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Name</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="name_le"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>GeoNode URL</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="url_le"/>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QgsAuthConfigSelect" name="authcfg_acs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="minimumSize">
+     <property name="sizeHint" stdset="0">
       <size>
-       <width>0</width>
-       <height>30</height>
+       <width>20</width>
+       <height>13</height>
       </size>
      </property>
-    </widget>
+    </spacer>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -71,7 +44,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_2">
+       <layout class="QGridLayout" name="grid_layout_2">
         <item row="0" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -140,6 +113,46 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="grid_layout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="name_label">
+       <property name="text">
+        <string>Name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="name_le"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="url_label">
+       <property name="text">
+        <string>GeoNode URL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="url_le"/>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QgsAuthConfigSelect" name="authcfg_acs">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0">
     <widget class="QPushButton" name="test_connection_btn">
      <property name="sizePolicy">
@@ -152,19 +165,6 @@
       <string>Test Connection</string>
      </property>
     </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>13</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -6,16 +6,16 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>597</width>
-    <height>323</height>
+    <width>596</width>
+    <height>311</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>GeoNode Connection Configuration</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QFormLayout" name="formLayout">
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
@@ -38,7 +38,7 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QgsAuthConfigSelect" name="authcfg_acs">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -54,14 +54,24 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="6" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="options_gb">
      <property name="title">
       <string>Options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QFormLayout" name="formLayout_2">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -130,7 +140,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0">
     <widget class="QPushButton" name="test_connection_btn">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -143,7 +153,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -155,16 +165,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -14,29 +14,18 @@
    <string>GeoNode Connection Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="0" column="0">
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Name</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="name_le"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>GeoNode URL</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="url_le"/>
-     </item>
-    </layout>
+   <item row="4" column="0">
+    <widget class="QPushButton" name="test_connection_btn">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Test Connection</string>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QgsAuthConfigSelect" name="authcfg_acs">
@@ -52,6 +41,54 @@
        <height>30</height>
       </size>
      </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QFrame" name="connection_details">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Name</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="name_le"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>GeoNode URL</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="url_le"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="6" column="0">
@@ -138,19 +175,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QPushButton" name="test_connection_btn">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Test Connection</string>
-     </property>
     </widget>
    </item>
    <item row="5" column="0">

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -7,27 +7,54 @@
     <x>0</x>
     <y>0</y>
     <width>596</width>
-    <height>313</height>
+    <height>311</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>GeoNode Connection Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="5" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="name_le"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>GeoNode URL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="url_le"/>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QgsAuthConfigSelect" name="authcfg_acs">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="sizeHint" stdset="0">
+     <property name="minimumSize">
       <size>
-       <width>20</width>
-       <height>13</height>
+       <width>0</width>
+       <height>30</height>
       </size>
      </property>
-    </spacer>
+    </widget>
    </item>
-   <item row="7" column="0">
+   <item row="6" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -44,7 +71,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="grid_layout_2">
+       <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -113,46 +140,6 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <layout class="QGridLayout" name="grid_layout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="name_label">
-       <property name="text">
-        <string>Name</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="name_le"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="url_label">
-       <property name="text">
-        <string>GeoNode URL</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="url_le"/>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QgsAuthConfigSelect" name="authcfg_acs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>30</height>
-      </size>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="0">
     <widget class="QPushButton" name="test_connection_btn">
      <property name="sizePolicy">
@@ -165,6 +152,19 @@
       <string>Test Connection</string>
      </property>
     </widget>
+   </item>
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>13</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Fixes https://github.com/kartoza/qgis_geonode/issues/70

Adds progress bar in the message bar, using the same approach used in the main widget to add the progress message when searching or loading resources.

![testing_connection](https://user-images.githubusercontent.com/2663775/113143300-a76faa80-9234-11eb-82e4-60f56e79ba9b.gif)
