### PR TITLE
Small handling error handling update

### DIFF
--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -330,7 +330,7 @@ class LayerLoaderTask(qgis.core.QgsTask):
             cloned_layer = self.layer.clone()
             self.layer_handler(cloned_layer)
         else:
-            message = f"Error loading layer {self.layer_uri!r}"
+            message = f"Error loading layer {self.uri!r}"
             log(message)
             self.error_handler(message)
 

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -167,7 +167,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
         self._get_datasource_widget().message_bar.clearWidgets()
 
     def handle_loading_error(
-        self, qt_error: str, http_status_code: int, http_status_reason: str
+        self, qt_error: str, http_status_code: int = 0, http_status_reason: str = None
     ):
         if http_status_code != 0:
             http_status = f"{http_status_code} - {http_status_reason}"


### PR DESCRIPTION
When handling errors from layer loading, this PR make the http status code and reason parameters optional, some errors might occur from QGIS process loading of layer and will have no http status code or reason.

This PR contains changes from https://github.com/kartoza/qgis_geonode/pull/156