### PR TITLE
Bump QGIS minimum version to 3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump minimum QGIS version to 3.18
+
 ## [0.3.4] - 2021-12-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ exclude = """\
 
 [tool.qgis-plugin.metadata]
 name = "QGIS GeoNode"
-qgisMinimumVersion = "3.10"
+qgisMinimumVersion = "3.18"
 icon = "mIconGeonode.svg"
 experimental = "True"
 deprecated = "False"
@@ -42,6 +42,9 @@ tracker = "https://github.com/kartoza/qgis_geonode/issues"
 repository = "https://github.com/kartoza/qgis_geonode"
 tags = [
     "geonode",
+    "wms",
+    "wfs",
+    "wcs",
 ]
 category = "plugins"
 hasProcessingProvider = "no"


### PR DESCRIPTION
This PR increases the minimum QGIS version to 3.18.

We need this as the minimum since the plugin is making use of a custom section on the layer properties dialog. Support for this for layers of type raster has been added as of QGIS v 3.18

fixes #187 