### PR TITLE
Implement update of metadata fields

### DIFF
--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -23,11 +23,10 @@ class BaseGeonodeClient(QtCore.QObject):
 
     dataset_list_received = QtCore.pyqtSignal(list, models.GeonodePaginationInfo)
     dataset_detail_received = QtCore.pyqtSignal(object)
+    dataset_detail_error_received = QtCore.pyqtSignal([str], [str, int, str])
     style_detail_received = QtCore.pyqtSignal(QtXml.QDomElement)
     keyword_list_received = QtCore.pyqtSignal(list)
-
     search_error_received = QtCore.pyqtSignal([str], [str, int, str])
-    dataset_detail_error_received = QtCore.pyqtSignal([str], [str, int, str])
 
     def __init__(
         self,

--- a/src/qgis_geonode/apiclient/version_postv2.py
+++ b/src/qgis_geonode/apiclient/version_postv2.py
@@ -26,6 +26,7 @@ class GeonodePostV2ApiClient(BaseGeonodeClient):
         models.ApiClientCapability.FILTER_BY_TEMPORAL_EXTENT,
         models.ApiClientCapability.LOAD_LAYER_METADATA,
         models.ApiClientCapability.LOAD_VECTOR_LAYER_STYLE,
+        models.ApiClientCapability.MODIFY_LAYER_METADATA,
         # NOTE: loading raster layer style is not present here
         # because QGIS does not currently support loading SLD for raster layers
         models.ApiClientCapability.MODIFY_VECTOR_LAYER_STYLE,
@@ -265,7 +266,7 @@ def _get_common_model_properties(raw_dataset: typing.Dict) -> typing.Dict:
         "title": raw_dataset.get("title", ""),
         "abstract": raw_dataset.get("raw_abstract", ""),
         "thumbnail_url": raw_dataset["thumbnail_url"],
-        "link": raw_dataset.get("link"),
+        "link": raw_dataset["link"],
         "detail_url": raw_dataset["detail_url"],
         "dataset_sub_type": type_,
         "service_urls": service_urls,

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -20,6 +20,7 @@ from ..apiclient import (
 from .. import network
 from ..apiclient.models import ApiClientCapability
 from ..conf import settings_manager
+from ..metadata import populate_metadata
 from ..resources import *
 from ..utils import log, tr
 
@@ -396,62 +397,3 @@ class LayerLoaderTask(qgis.core.QgsTask):
             params["authcfg"] = self.api_client.auth_config
         uri = " ".join(f"{key}='{value}'" for key, value in params.items())
         return qgis.core.QgsVectorLayer(uri, self.brief_dataset.title, "WFS")
-
-
-def populate_metadata(metadata: qgis.core.QgsLayerMetadata, dataset: models.Dataset):
-    metadata.setIdentifier(str(dataset.uuid))
-    metadata.setTitle(dataset.title)
-    metadata.setAbstract(dataset.abstract)
-    metadata.setLanguage(dataset.language)
-    metadata.setKeywords({"layer": dataset.keywords})
-    if dataset.category:
-        metadata.setCategories([dataset.category])
-    if dataset.license:
-        metadata.setLicenses([dataset.license])
-    if dataset.constraints:
-        constraints = [qgis.core.QgsLayerMetadata.Constraint(dataset.constraints)]
-        metadata.setConstraints(constraints)
-    metadata.setCrs(dataset.srid)
-    spatial_extent = qgis.core.QgsLayerMetadata.SpatialExtent()
-    spatial_extent.extentCrs = dataset.srid
-    if dataset.spatial_extent:
-        spatial_extent.bounds = dataset.spatial_extent.toBox3d(0, 0)
-        if dataset.temporal_extent:
-            metadata.extent().setTemporalExtents(
-                [
-                    qgis.core.QgsDateTimeRange(
-                        dataset.temporal_extent[0],
-                        dataset.temporal_extent[1],
-                    )
-                ]
-            )
-
-    metadata.extent().setSpatialExtents([spatial_extent])
-    if dataset.owner:
-        owner_contact = qgis.core.QgsAbstractMetadataBase.Contact(dataset.owner)
-        owner_contact.role = tr("owner")
-        metadata.addContact(owner_contact)
-    if dataset.metadata_author:
-        metadata_author = qgis.core.QgsAbstractMetadataBase.Contact(
-            dataset.metadata_author
-        )
-        metadata_author.role = tr("metadata_author")
-        metadata.addContact(metadata_author)
-    links = []
-    if dataset.thumbnail_url:
-        link = qgis.core.QgsAbstractMetadataBase.Link(
-            tr("Thumbnail"), tr("Thumbail_link"), dataset.thumbnail_url
-        )
-        links.append(link)
-    if dataset.link:
-        link = qgis.core.QgsAbstractMetadataBase.Link(
-            tr("API"), tr("API_URL"), dataset.link
-        )
-        links.append(link)
-    if dataset.detail_url:
-        link = qgis.core.QgsAbstractMetadataBase.Link(
-            tr("Detail"), tr("Detail_URL"), dataset.detail_url
-        )
-        links.append(link)
-    metadata.setLinks(links)
-    return metadata

--- a/src/qgis_geonode/metadata.py
+++ b/src/qgis_geonode/metadata.py
@@ -1,0 +1,64 @@
+import qgis.core
+
+from .apiclient import models
+from .utils import tr
+
+
+def populate_metadata(
+    metadata: qgis.core.QgsLayerMetadata, dataset: models.Dataset
+) -> qgis.core.QgsLayerMetadata:
+    metadata.setIdentifier(str(dataset.uuid))
+    metadata.setTitle(dataset.title)
+    metadata.setAbstract(dataset.abstract)
+    metadata.setLanguage(dataset.language)
+    metadata.setKeywords({"layer": dataset.keywords})
+    if dataset.category:
+        metadata.setCategories([dataset.category])
+    if dataset.license:
+        metadata.setLicenses([dataset.license])
+    if dataset.constraints:
+        constraints = [qgis.core.QgsLayerMetadata.Constraint(dataset.constraints)]
+        metadata.setConstraints(constraints)
+    metadata.setCrs(dataset.srid)
+    spatial_extent = qgis.core.QgsLayerMetadata.SpatialExtent()
+    spatial_extent.extentCrs = dataset.srid
+    if dataset.spatial_extent:
+        spatial_extent.bounds = dataset.spatial_extent.toBox3d(0, 0)
+        if dataset.temporal_extent:
+            metadata.extent().setTemporalExtents(
+                [
+                    qgis.core.QgsDateTimeRange(
+                        dataset.temporal_extent[0],
+                        dataset.temporal_extent[1],
+                    )
+                ]
+            )
+    metadata.extent().setSpatialExtents([spatial_extent])
+    if dataset.owner:
+        owner_contact = qgis.core.QgsAbstractMetadataBase.Contact(dataset.owner)
+        owner_contact.role = tr("owner")
+        metadata.addContact(owner_contact)
+    if dataset.metadata_author:
+        metadata_author = qgis.core.QgsAbstractMetadataBase.Contact(
+            dataset.metadata_author
+        )
+        metadata_author.role = tr("metadata_author")
+        metadata.addContact(metadata_author)
+    links = []
+    if dataset.thumbnail_url:
+        link = qgis.core.QgsAbstractMetadataBase.Link(
+            tr("Thumbnail"), tr("Thumbail_link"), dataset.thumbnail_url
+        )
+        links.append(link)
+    if dataset.link:
+        link = qgis.core.QgsAbstractMetadataBase.Link(
+            tr("API"), tr("API_URL"), dataset.link
+        )
+        links.append(link)
+    if dataset.detail_url:
+        link = qgis.core.QgsAbstractMetadataBase.Link(
+            tr("Detail"), tr("Detail_URL"), dataset.detail_url
+        )
+        links.append(link)
+    metadata.setLinks(links)
+    return metadata

--- a/src/qgis_geonode/network.py
+++ b/src/qgis_geonode/network.py
@@ -18,9 +18,10 @@ UNSUPPORTED_REMOTE = "unsupported"
 
 
 class HttpMethod(enum.Enum):
-    GET = "get"
-    POST = "post"
-    PUT = "put"
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
 
 
 @dataclasses.dataclass()
@@ -219,6 +220,12 @@ class NetworkRequestTask(qgis.core.QgsTask):
         elif method == HttpMethod.PUT:
             data_ = QtCore.QByteArray(payload.encode())
             reply = self.network_access_manager.put(request, data_)
+        elif method == HttpMethod.PATCH:
+            data_ = QtCore.QByteArray(payload.encode())
+            # QNetworkAccess manager does not have a patch() method
+            reply = self.network_access_manager.sendCustomRequest(
+                request, QtCore.QByteArray(HttpMethod.PATCH.value.encode()), data_
+            )
         else:
             raise NotImplementedError
         return reply

--- a/src/qgis_geonode/ui/qgis_geonode_layer_dialog.ui
+++ b/src/qgis_geonode/ui/qgis_geonode_layer_dialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>664</width>
-    <height>333</height>
+    <height>366</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Geonode Layer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QgsCollapsibleGroupBox" name="links_gb">
      <property name="title">
@@ -86,6 +86,36 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="metadata_gb">
+     <property name="title">
+      <string>Metadata</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QPushButton" name="download_metadata_pb">
+          <property name="text">
+           <string>Reload metadata from GeoNode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="upload_metadata_pb">
+          <property name="text">
+           <string>Save current metadata to GeoNode</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This PR implements loading and saving some metadata fields of a QGIS layer to the corresponding GeoNode dataset.

Implementation is similar to how #185 allowed saving/loading styles back to GeoNode. For now, uploading metadata back to GeoNode is restricted to:

- `title`
- `abstract`

fixes #189 