### PR TITLE
Remove empty reference to the plugin in QGIS plugins menu

### DIFF
--- a/src/qgis_geonode/main.py
+++ b/src/qgis_geonode/main.py
@@ -129,15 +129,6 @@ class QgisGeoNode:
         return action
 
     def initGui(self):
-        """Create the menu entries and toolbar icons inside the QGIS GUI."""
-        icon_path = ":/plugins/Qgis_GeoNode/icon.png"
-        self.add_action(
-            icon_path,
-            text=self.tr(u""),
-            callback=self.run,
-            parent=self.iface.mainWindow(),
-        )
-
         self.iface.registerMapLayerConfigWidgetFactory(
             self.layer_properties_config_widget_factory
         )


### PR DESCRIPTION
This PR remove the empty reference to the plugin in QGIS' plugins menu

fixes #180