### PR TITLE
Export and upload SLD file with layer style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Layer uploads also send SLD style
 
 
 ## [0.5.0] - 2021-12-29

--- a/poetry.lock
+++ b/poetry.lock
@@ -450,6 +450,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "pyqt5-stubs"
+version = "5.15.2.0"
+description = "PEP561 stub files for the PyQt5 framework"
+category = "main"
+optional = false
+python-versions = ">= 3.5"
+
+[package.extras]
+build = ["docker (==4.2.0)"]
+
+[[package]]
 name = "pytest"
 version = "6.2.1"
 description = "pytest: simple powerful testing with Python"
@@ -673,7 +684,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "9e597803fed93fed9853bd991ebea11f9b4a08d8862ebf4b945a26691123bc41"
+content-hash = "9f6ba5e5324525b3cac39f4d8131bb94ffdb08291299a8604b1a4ea0b0665c42"
 
 [metadata.files]
 appdirs = [
@@ -884,6 +895,10 @@ pymdown-extensions = [
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pyqt5-stubs = [
+    {file = "PyQt5-stubs-5.15.2.0.tar.gz", hash = "sha256:dc0dea66f02fe297fb0cddd5767fbf58275b54ecb67f69ebeb994e1553bfb9b2"},
+    {file = "PyQt5_stubs-5.15.2.0-py3-none-any.whl", hash = "sha256:4b750d04ffca1bb188615d1a4e7d655a1d81d30df6ee3488f0adfe09b78e3d36"},
 ]
 pytest = [
     {file = "pytest-6.2.1-py3-none-any.whl", hash = "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pymdown-extensions = "^8.1.1"
 pytest-custom-exit-code = "^0.3.0"
 mypy = "^0.930"
 qgis-stubs = "^0.1.0"
+PyQt5-stubs = "^5.15.2"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This PR implements export of a layer's style via SLD and subsequent upload to GeoNode. This way, when creating a new GeoNode dataset from QGIS it will include the QGIS style too

fixes #194