### PR TITLE
Fix dataset abstract not being shown on the search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix dataset abstract not being shown on the UI anymore
+- Updated user guide
 - Layer uploads also send SLD style
 - Connection test uses auth credentials, if available
 

--- a/src/qgis_geonode/apiclient/geonode_v3.py
+++ b/src/qgis_geonode/apiclient/geonode_v3.py
@@ -746,7 +746,7 @@ def _get_common_model_properties(raw_dataset: typing.Dict) -> typing.Dict:
         "uuid": uuid.UUID(raw_dataset["uuid"]),
         "name": raw_dataset.get("alternate", raw_dataset.get("name", "")),
         "title": raw_dataset.get("title", ""),
-        "abstract": raw_dataset.get("raw_abstract", ""),
+        "abstract": raw_dataset.get("raw_abstract", raw_dataset.get("abstract", "")),
         "thumbnail_url": raw_dataset["thumbnail_url"],
         "link": raw_dataset["link"],
         "detail_url": raw_dataset["detail_url"],

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -124,6 +124,7 @@ class SearchResultWidget(QtWidgets.QWidget, WidgetUi):
     def _initialize_ui(self):
         self.title_la.setText(f"<h3>{self.brief_dataset.title}</h3>")
         self.resource_type_la.setText(self.brief_dataset.dataset_sub_type.value)
+        self.description_la.setText(self.brief_dataset.abstract)
         if self.brief_dataset.detail_url:
             self.browser_btn.setIcon(
                 QtGui.QIcon(":/plugins/qgis_geonode/mIconGeonode.svg")


### PR DESCRIPTION
This PR fixes a recent regression whereby a dataset's abstract was no longer being shown on the search results listing

fixes #206 