### PR TITLE
Remove usage of the typing.Final type annotation

### DIFF
--- a/src/qgis_geonode/apiclient/geonode_v3.py
+++ b/src/qgis_geonode/apiclient/geonode_v3.py
@@ -469,10 +469,8 @@ class GeonodeApiClientVersion_3_3_0(GeonodeApiClientVersion_3_x):
 
 
 class LayerUploaderTask(network.NetworkRequestTask):
-    VECTOR_UPLOAD_FORMAT: typing.Final[ExportFormat] = ExportFormat(
-        "ESRI Shapefile", "shp"
-    )
-    RASTER_UPLOAD_FORMAT: typing.Final[ExportFormat] = ExportFormat("GTiff", "tif")
+    VECTOR_UPLOAD_FORMAT = ExportFormat("ESRI Shapefile", "shp")
+    RASTER_UPLOAD_FORMAT = ExportFormat("GTiff", "tif")
 
     layer: qgis.core.QgsMapLayer
     allow_public_access: bool

--- a/src/qgis_geonode/network.py
+++ b/src/qgis_geonode/network.py
@@ -61,8 +61,8 @@ def _get_qt_network_reply_error_mapping() -> typing.Dict:
     return result
 
 
-_Q_NETWORK_REPLY_ERROR_MAP: typing.Final[
-    typing.Dict[QtNetwork.QNetworkReply.NetworkError, str]
+_Q_NETWORK_REPLY_ERROR_MAP: typing.Dict[
+    QtNetwork.QNetworkReply.NetworkError, str
 ] = _get_qt_network_reply_error_mapping()
 
 


### PR DESCRIPTION
This type annotation got introduced in Python 3.8 and we are supporting Python 3.7 (which is used on OSGEO4W)

fixes #213