### PR TITLE
Fix possibly empty dataset type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Remove unsupported f-string formatting on Python3.7
+- Assign `UNKNOWN` as dataset type when the remote does not report it
 
 
 ## [0.9.4] - 2022-02-07

--- a/src/qgis_geonode/apiclient/geonode_v3.py
+++ b/src/qgis_geonode/apiclient/geonode_v3.py
@@ -345,7 +345,7 @@ class GeonodeApiClientVersion_3_4_0(GeonodeApiClientVersion_3_x):
         elif dataset_type == models.GeonodeResourceType.RASTER_LAYER:
             result[models.GeonodeService.OGC_WCS] = _get_link(raw_links, "OGC:WCS")
         else:
-            log(f"Invalid dataset type: {dataset_type=}")
+            log(f"Invalid dataset type: {dataset_type}")
             result = {}
         auth_manager = qgis.core.QgsApplication.authManager()
         auth_provider_name = auth_manager.configAuthMethodKey(self.auth_config).lower()
@@ -474,7 +474,7 @@ class GeonodeApiClientVersion_3_3_0(GeonodeApiClientVersion_3_x):
         elif dataset_type == models.GeonodeResourceType.RASTER_LAYER:
             result[models.GeonodeService.OGC_WCS] = raw_dataset["ows_url"]
         else:
-            log(f"Invalid dataset type: {dataset_type=}")
+            log(f"Invalid dataset type: {dataset_type}")
             result = {}
         auth_manager = qgis.core.QgsApplication.authManager()
         auth_provider_name = auth_manager.configAuthMethodKey(self.auth_config).lower()
@@ -490,7 +490,7 @@ class GeonodeApiClientVersion_3_3_0(GeonodeApiClientVersion_3_x):
         type_ = {
             "coverageStore": models.GeonodeResourceType.RASTER_LAYER,
             "dataStore": models.GeonodeResourceType.VECTOR_LAYER,
-        }.get(raw_dataset.get("storeType"))
+        }.get(raw_dataset.get("storeType"), models.GeonodeResourceType.UNKNOWN)
         service_urls = self._get_service_urls(raw_dataset, type_)
         raw_style = raw_dataset.get("default_style") or {}
         return {
@@ -850,7 +850,7 @@ def _get_resource_type(
     result = {
         "raster": models.GeonodeResourceType.RASTER_LAYER,
         "vector": models.GeonodeResourceType.VECTOR_LAYER,
-    }.get(raw_dataset.get("subtype"))
+    }.get(raw_dataset.get("subtype"), models.GeonodeResourceType.UNKNOWN)
     return result
 
 

--- a/src/qgis_geonode/apiclient/legacy.py
+++ b/src/qgis_geonode/apiclient/legacy.py
@@ -254,7 +254,10 @@ def _get_resource_type(
     type_ = {
         "dataStore": models.GeonodeResourceType.VECTOR_LAYER,
         "coverageStore": models.GeonodeResourceType.RASTER_LAYER,
-    }.get(raw_dataset.get("storeType", raw_dataset.get("store_type")))
+    }.get(
+        raw_dataset.get("storeType", raw_dataset.get("store_type")),
+        models.GeonodeResourceType.UNKNOWN,
+    )
     return type_
 
 

--- a/src/qgis_geonode/apiclient/models.py
+++ b/src/qgis_geonode/apiclient/models.py
@@ -84,6 +84,7 @@ class GeonodeService(enum.Enum):
 class GeonodeResourceType(enum.Enum):
     VECTOR_LAYER = "vector"
     RASTER_LAYER = "raster"
+    UNKNOWN = "unknown"
 
 
 @dataclasses.dataclass

--- a/test/test_apiclient_geonode_v3.py
+++ b/test/test_apiclient_geonode_v3.py
@@ -69,7 +69,7 @@ def test_get_temporal_extent(payload, expected):
     [
         pytest.param({"subtype": "raster"}, models.GeonodeResourceType.RASTER_LAYER),
         pytest.param({"subtype": "vector"}, models.GeonodeResourceType.VECTOR_LAYER),
-        pytest.param({}, None),
+        pytest.param({}, models.GeonodeResourceType.UNKNOWN),
     ],
 )
 def test_get_resource_type(raw_dataset, expected):


### PR DESCRIPTION
This PR fixes a couple of bugs:

- Always provide a known value for dataset types, even when nothing is reported by the remote GeoNode. In this case we assign `GeonodeResourceType.UNKNOWN`
- Do not use f-string debug formatting in the form `f"{some_variable=}"` as this is not supported on Python 3.7, which is still the target version of Python for OSGEO4W