### PR TITLE
Add new configuration option to choose WFS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
 - Remove unsupported f-string formatting on Python3.7
 - Assign `UNKNOWN` as dataset type when the remote does not report it
+- Add new WFS version config option and default to WFS v1.1.0
+
 
 
 ## [0.9.4] - 2022-02-07

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,6 +28,15 @@ In order to add a new GeoNode connection:
     | GeoNode URL | The base URL of the GeoNode being connected to (_e.g._ <https://stable.demo.geonde.org>) |
     | Authentication | Whether to use authentication to connect to GeoNode or not. See the [Configure authentication](#configure-authentication) section below for more details on how to configure authenticated access to GeoNode |
     | Page size | How many search results per page shall be shown by QGIS. This defaults to `10` |
+    | WFS version | Which version of the Web Feature Service (WFS) to use for requesting vector layers from the remote GeoNode. Defaults to `v1.1.0`. |
+
+    !!! Note
+        There is currently a bug in QGIS which prevents using WFS version 2.0.0 for editing a vector layer's geometry,
+
+        <https://github.com/qgis/QGIS/issues/47254>
+
+        Therefore, for the time being, we reccomend using WFS version 1.1.0, which works OK.
+
 
 5. Optionally you may now click the `Test Connection` button. QGIS will then
     try to connect to GeoNode in order to discover what version of GeoNode is

--- a/src/qgis_geonode/apiclient/base.py
+++ b/src/qgis_geonode/apiclient/base.py
@@ -22,6 +22,7 @@ class BaseGeonodeClient(QtCore.QObject):
     network_fetcher_task: typing.Optional[network.NetworkRequestTask]
     capabilities: typing.List[models.ApiClientCapability]
     page_size: int
+    wfs_version: conf.WfsVersion
     network_requests_timeout: int
 
     dataset_list_received = QtCore.pyqtSignal(list, models.GeonodePaginationInfo)
@@ -38,6 +39,7 @@ class BaseGeonodeClient(QtCore.QObject):
         self,
         base_url: str,
         page_size: int,
+        wfs_version: conf.WfsVersion,
         network_requests_timeout: int,
         auth_config: typing.Optional[str] = None,
     ):
@@ -45,6 +47,7 @@ class BaseGeonodeClient(QtCore.QObject):
         self.auth_config = auth_config or ""
         self.base_url = base_url.rstrip("/")
         self.page_size = page_size
+        self.wfs_version = wfs_version
         self.network_requests_timeout = network_requests_timeout
         self.network_fetcher_task = None
 
@@ -53,6 +56,7 @@ class BaseGeonodeClient(QtCore.QObject):
         return cls(
             base_url=connection_settings.base_url,
             page_size=connection_settings.page_size,
+            wfs_version=connection_settings.wfs_version,
             auth_config=connection_settings.auth_config,
             network_requests_timeout=connection_settings.network_requests_timeout,
         )

--- a/src/qgis_geonode/apiclient/geonode_v3.py
+++ b/src/qgis_geonode/apiclient/geonode_v3.py
@@ -303,9 +303,13 @@ class GeonodeApiClientVersion_3_4_0(GeonodeApiClientVersion_3_x):
         )
 
     def handle_layer_upload(self, result: bool):
+        success_statuses = (
+            200,
+            201,
+        )
         if result:
             response_contents = self.network_fetcher_task.response_contents[0]
-            if response_contents.http_status_code == 201:
+            if response_contents.http_status_code in success_statuses:
                 deserialized = network.deserialize_json_response(
                     response_contents.response_body
                 )

--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -1,5 +1,6 @@
 import contextlib
 import dataclasses
+import enum
 import json
 import typing
 import uuid
@@ -33,6 +34,13 @@ def _get_network_requests_timeout():
     )
 
 
+class WfsVersion(enum.Enum):
+    V_1_0_0 = "1.0.0"
+    V_1_1_0 = "1.1.0"
+    V_2_0_0 = "2.0.0"
+    AUTO = "auto"
+
+
 @dataclasses.dataclass
 class ConnectionSettings:
     """Helper class to manage settings for a Connection"""
@@ -45,6 +53,7 @@ class ConnectionSettings:
         default_factory=_get_network_requests_timeout, init=False
     )
     geonode_version: typing.Optional[packaging_version.Version] = None
+    wfs_version: typing.Optional[WfsVersion] = WfsVersion.AUTO
     auth_config: typing.Optional[str] = None
 
     @classmethod
@@ -65,6 +74,7 @@ class ConnectionSettings:
             page_size=int(settings.value("page_size", defaultValue=10)),
             auth_config=reported_auth_cfg,
             geonode_version=geonode_version,
+            wfs_version=WfsVersion(settings.value("wfs_version", "1.1.0")),
         )
 
     def to_json(self):
@@ -78,6 +88,7 @@ class ConnectionSettings:
                 "geonode_version": str(self.geonode_version)
                 if self.geonode_version is not None
                 else None,
+                "wfs_version": self.wfs_version.value,
             }
         )
 
@@ -151,6 +162,7 @@ class SettingsManager(QtCore.QObject):
             settings.setValue("name", connection_settings.name)
             settings.setValue("base_url", connection_settings.base_url)
             settings.setValue("page_size", connection_settings.page_size)
+            settings.setValue("wfs_version", connection_settings.wfs_version.value)
             settings.setValue("auth_config", connection_settings.auth_config)
             settings.setValue(
                 "geonode_version",

--- a/src/qgis_geonode/gui/search_result_widget.py
+++ b/src/qgis_geonode/gui/search_result_widget.py
@@ -394,7 +394,7 @@ class LayerLoaderTask(qgis.core.QgsTask):
             "srsname": f"EPSG:{self.brief_dataset.srid.postgisSrid()}",
             "typename": self.brief_dataset.name,
             "url": self.brief_dataset.service_urls[self.service_type].rstrip("/"),
-            "version": "auto",
+            "version": self.api_client.wfs_version.value,
         }
         if self.api_client.auth_config:
             params["authcfg"] = self.api_client.auth_config

--- a/src/qgis_geonode/ui/connection_dialog.ui
+++ b/src/qgis_geonode/ui/connection_dialog.ui
@@ -113,6 +113,27 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>WFS version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QComboBox" name="wfs_version_cb"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="detect_wfs_version_pb">
+          <property name="text">
+           <string>Detect</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>

--- a/test/test_apiclient_geonode_v3.py
+++ b/test/test_apiclient_geonode_v3.py
@@ -7,6 +7,7 @@ import pytest
 import qgis.core
 from qgis.PyQt import QtCore
 
+from qgis_geonode.conf import WfsVersion
 from qgis_geonode.apiclient import (
     geonode_v3,
     models,
@@ -110,7 +111,7 @@ def test_parse_datetime(raw_value, expected):
 )
 def test_apiclient_v_3_3_0_dataset_list_url(base_url, expected):
     client = geonode_v3.GeonodeApiClientVersion_3_3_0(
-        base_url, 10, network_requests_timeout=0
+        base_url, 10, wfs_version=WfsVersion.V_1_1_0, network_requests_timeout=0
     )
     assert client.dataset_list_url == expected
 
@@ -131,7 +132,9 @@ def test_apiclient_v_3_3_0_dataset_list_url(base_url, expected):
     ],
 )
 def test_apiclient_dataset_list_url(client_class: typing.Type, base_url, expected):
-    client = client_class(base_url, 10, network_requests_timeout=0)
+    client = client_class(
+        base_url, 10, wfs_version=WfsVersion.V_1_1_0, network_requests_timeout=0
+    )
     assert client.dataset_list_url == expected
 
 
@@ -155,7 +158,9 @@ def test_apiclient_dataset_list_url(client_class: typing.Type, base_url, expecte
 def test_apiclient_get_dataset_detail_url(
     client_class: typing.Type, base_url, dataset_id, expected
 ):
-    client = client_class(base_url, 10, network_requests_timeout=0)
+    client = client_class(
+        base_url, 10, wfs_version=WfsVersion.V_1_1_0, network_requests_timeout=0
+    )
     result = client.get_dataset_detail_url(dataset_id)
     assert result.toString() == expected
 
@@ -350,7 +355,9 @@ def test_apiclient_get_dataset_detail_url(
 def test_apiclient_build_search_filters(
     client_class: typing.Type, search_filters, expected
 ):
-    client = client_class("phony-base-url", 10, network_requests_timeout=0)
+    client = client_class(
+        "phony-base-url", 10, wfs_version=WfsVersion.V_1_1_0, network_requests_timeout=0
+    )
     result = client.build_search_query(search_filters)
     assert result.toString() == expected
 
@@ -419,7 +426,9 @@ def test_get_common_model_properties_client_v_3_4_0():
             name="fake-style-name", sld_url="fake-sld-url"
         ),
     }
-    client = geonode_v3.GeonodeApiClientVersion_3_4_0("fake-base-url", 10, 0)
+    client = geonode_v3.GeonodeApiClientVersion_3_4_0(
+        "fake-base-url", 10, WfsVersion.V_1_1_0, 0
+    )
     result = client._get_common_model_properties(raw_dataset)
     for k, v in expected.items():
         assert result[k] == v


### PR DESCRIPTION
This PR adds a new configuration option to allow selecting which WFS version to use when loading and editing remote WFS layers

fixes #225