### PR TITLE
Improve widget focus behavior on main search dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Improve plugin description when viewed through QGIS plugin manager
+- Improve focus behavior for searching datasets in QGIS data source dialog
 
 
 ## [0.9.5] - 2022-02-09

--- a/src/qgis_geonode/gui/geonode_data_source_widget.py
+++ b/src/qgis_geonode/gui/geonode_data_source_widget.py
@@ -184,12 +184,17 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
         self.spatial_extent_box.extentChanged.connect(self.store_search_filters)
         self.sort_field_cmb.currentIndexChanged.connect(self.store_search_filters)
         self.reverse_order_chb.toggled.connect(self.store_search_filters)
+        for button in self.findChildren(QtWidgets.QPushButton):
+            button.setAutoDefault(False)
+            button.setDefault(False)
+        self.search_btn.setDefault(True)
         self.restore_search_filters()
 
         # this method calls connections_cmb.setCurrentIndex(), which in turn emits
         # connections_cmb.currentIndexChanged, which causes
         # self.activate_connection_configuration to run
         self.update_connections_combobox()
+        self.title_le.returnPressed.connect(self.search_geonode)
 
     def _initialize_spatial_extent_box(self):
         # ATTENTION: the order of initialization of the self.spatial_extent_box widget
@@ -483,6 +488,7 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             self.show_message(message, level=qgis.core.Qgis.Critical)
         self.toggle_search_controls(True)
         self.toggle_search_buttons()
+        self.title_le.setFocus()
 
     def handle_search_error(
         self,


### PR DESCRIPTION
This PR improves the automatic focus of the main `Search` button in the QGIS data source manager dialogue.

Additionally, it also sets the focus on the `title` line edit right after a search has ended. It would also be nice to make this widget gain focus automatically when the dialog is opened (or the plugin tab is selected by the user) but that does not seem to be possible, as there does not seem to be a way to let the plugin run code after the dialogue is shown

fixes #230