### PR TITLE
Do not try to parse GeoNode version when we know the connection URL is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve plugin description when viewed through QGIS plugin manager
 - Improve focus behavior for searching datasets in QGIS data source dialog
+- Improve handling of invalid connections
 
 
 ## [0.9.5] - 2022-02-09

--- a/src/qgis_geonode/conf.py
+++ b/src/qgis_geonode/conf.py
@@ -12,6 +12,7 @@ from qgis.core import QgsRectangle, QgsSettings
 
 from .apiclient import models
 from .apiclient.models import GeonodeResourceType, IsoTopicCategory
+from .network import UNSUPPORTED_REMOTE
 from .utils import log
 from .vendor.packaging import version as packaging_version
 
@@ -62,11 +63,11 @@ class ConnectionSettings:
             reported_auth_cfg = settings.value("auth_config").strip()
         except AttributeError:
             reported_auth_cfg = None
-        raw_geonode_version = settings.value("geonode_version") or None
-        if raw_geonode_version is not None:
+        raw_geonode_version = settings.value("geonode_version") or UNSUPPORTED_REMOTE
+        if raw_geonode_version != UNSUPPORTED_REMOTE:
             geonode_version = packaging_version.parse(raw_geonode_version)
         else:
-            geonode_version = None
+            geonode_version = UNSUPPORTED_REMOTE
         return cls(
             id=uuid.UUID(connection_identifier),
             name=settings.value("name"),

--- a/src/qgis_geonode/gui/geonode_data_source_widget.py
+++ b/src/qgis_geonode/gui/geonode_data_source_widget.py
@@ -313,14 +313,17 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
                     # don't know if current config is valid or not yet, need to detect it
                     pass
             self.update_gui(current_connection)
-        self.toggle_search_buttons()
+            self.toggle_search_buttons()
 
     def toggle_search_buttons(self, enable: typing.Optional[bool] = None):
         enable_search = False
         enable_previous = False
         enable_next = False
         if enable is None or enable:
-            if self.connections_cmb.currentText() != "":
+            current_connection = conf.settings_manager.get_current_connection_settings()
+            if current_connection.geonode_version == network.UNSUPPORTED_REMOTE:
+                enable_search = False
+            else:
                 for check_box in self.resource_types_btngrp.buttons():
                     if check_box.isChecked():
                         enable_search = True


### PR DESCRIPTION
This PR fixes a bug where the plugin was trying to parse the GeoNode version even when it had been previously set to `network.UNSUPPORTED_REMOTE` and subsequently failed.

The proposed implementation does a stricter check and even disables the `search` button if the current connection is known not to be valid

fixes #231