### PR TITLE
make sure default wfs version is 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed first usage crash due to there not being a current connection
+- Changed default WFS version for new connections is now 1.1.0, which is known to work OK when editing vector 
+  layers via WFS
 
 
 ## [1.0.0-rc1] - 2022-02-23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,9 @@ hasProcessingProvider = "no"
 about = """\
 This plugin adds GeoNode client functionality to QGIS - search, load and manage GeoNode resources from inside QGIS.
 
-Initial development has been funded by the Pacific Community (SPC) and implemented by the Kartoza and GeoSolutions \
-teams. The plugin is actively maintained and aims to keep up to date with changes in the GeoNode API.
+Initial development has been commissioned by the by the Pacific Community (SPC), with funcding from the World Bank, \
+and implemented by the Kartoza and GeoSolutions teams. The plugin is actively maintained and aims to keep up to \
+date with changes in the GeoNode API.
 
 Check the website for a user guide and more detail.\
 """

--- a/src/qgis_geonode/gui/connection_dialog.py
+++ b/src/qgis_geonode/gui/connection_dialog.py
@@ -112,6 +112,8 @@ class ConnectionDialog(QtWidgets.QDialog, DialogUi):
         self.wfs_version_cb.clear()
         for name, member in WfsVersion.__members__.items():
             self.wfs_version_cb.addItem(member.value, member)
+        v_1_1_0_index = self.wfs_version_cb.findData(WfsVersion.V_1_1_0)
+        self.wfs_version_cb.setCurrentIndex(v_1_1_0_index)
 
     def detect_wfs_version(self):
         for widget in self._widgets_to_toggle_during_connection_test:


### PR DESCRIPTION
This PR implements default selection of WFS version 1.1.0 on the new connection dialog. This shall ensure that by default the plugin is configured to use a WFS version which is known to work OK also for performing WFS editing.

fixes #244