### PR TITLE
Fix #311 : Exception when dealing with malformed SLD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # Development
 .idea/
 .vscode/
+# Generated files
+src/qgis_geonode/metadata.txt
+src/qgis_geonode/resources.py

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -57,7 +57,10 @@ def url_from_geoserver(base_url: str, raw_url: str):
     try:
         url_path = urlparse(raw_url).path.strip("/")
     except TypeError:
-        QgsMessageLog.logMessage("Incorrect type returned from GeoServer", "GeoNode", Qgis.Warning )
+        QgsMessageLog.logMessage(
+            "Incorrect type returned from GeoServer", 
+            "GeoNode", 
+            Qgis.Warning)
         return None
 
     url_path = url_path.split("/")

--- a/src/qgis_geonode/utils.py
+++ b/src/qgis_geonode/utils.py
@@ -54,7 +54,11 @@ def remove_comments_from_sld(element):
 def url_from_geoserver(base_url: str, raw_url: str):
 
     # Clean the URL path from trailing and back slashes
-    url_path = urlparse(raw_url).path.strip("/")
+    try:
+        url_path = urlparse(raw_url).path.strip("/")
+    except TypeError:
+        QgsMessageLog.logMessage("Incorrect type returned from GeoServer", "GeoNode", Qgis.Warning )
+        return None
 
     url_path = url_path.split("/")
     # re-join URL path without the geoserver path


### PR DESCRIPTION
Please see details at #311 - this PR just band-aid deals with exceptions raised from invalid URLS returned from the GeoNode API.