### PR TITLE
Fix positional-args bug in discover_api_client → handle_api_client_di…

### DIFF
--- a/src/qgis_geonode/gui/geonode_data_source_widget.py
+++ b/src/qgis_geonode/gui/geonode_data_source_widget.py
@@ -25,7 +25,7 @@ from .. import (
 from ..apiclient.models import ApiClientCapability, IsoTopicCategory
 from ..gui.connection_dialog import ConnectionDialog
 from ..gui.search_result_widget import SearchResultWidget
-from ..httpclient import NetworkError, NetworkResponse, Request
+from ..httpclient import NetworkError, Request
 from ..utils import (
     tr,
 )
@@ -473,14 +473,24 @@ class GeonodeDataSourceWidget(qgis.gui.QgsAbstractDataSourceWidget, WidgetUi):
             timeout_ms=current_connection.network_requests_timeout,
             parent=self,
         )
+        # A lambda — not partial — is required here. ``finished`` emits one
+        # positional NetworkResponse; ``partial(handler, next_, *next_args)``
+        # would *append* that NetworkResponse after the bound args, which
+        # quietly mis-slots ``response`` as ``next_args[0]`` whenever the
+        # caller passes any positional next_args (e.g.
+        # ``discover_api_client(self._apply_active_connection,
+        # current_connection)``). The lambda explicitly discards the
+        # NetworkResponse — handle_api_client_discovery doesn't need it; the
+        # api-support cache is the source of truth by the time it runs.
         self.discovery_task.finished.connect(
-            partial(self.handle_api_client_discovery, next_, *next_args, **next_kwargs)
+            lambda _response: self.handle_api_client_discovery(
+                next_, *next_args, **next_kwargs
+            )
         )
 
     def handle_api_client_discovery(
         self,
         next_: typing.Callable,
-        response: NetworkResponse,
         *next_args,
         **next_kwargs,
     ):


### PR DESCRIPTION
…scovery

When discover_api_client is called with positional next_args (e.g. ``self.discover_api_client(self._apply_active_connection, current_connection)`` from activate_connection_configuration's cold-cache path), the cached NetworkResponse was being silently mis-slotted into the response-less next_() callable, manifesting as

    AttributeError: 'NetworkResponse' object has no attribute 'base_url'

inside _apply_active_connection.

The cause: ``finished`` emits one positional NetworkResponse, and ``partial(handler, next_, *next_args)`` *appends* that NetworkResponse to the end of the bound args. The handler's signature was

    handle_api_client_discovery(next_, response, *next_args, **next_kwargs)

so when next_args was non-empty the call became
``handle_api_client_discovery(next_, current_connection, NetworkResponse)`` — current_connection in the response slot, the actual response in *next_args. Then ``next_(*next_args, **next_kwargs)`` invoked self._apply_active_connection(NetworkResponse) instead of self._apply_active_connection(current_connection).

The contract was already wrong in the legacy code (same partial/append shape with ``task_result: bool`` in place of ``response``), but every caller used kwargs only, so it never tripped. Phase 3 introduced the positional-arg call site and exposed it; Phase 6 made it the default path on cold-cache connection switches.

Fix:

* Replace the partial with a lambda that explicitly discards the NetworkResponse and forwards next_ / next_args / next_kwargs as-is.
* Drop the unused ``response`` parameter from handle_api_client_discovery — the handler doesn't read the response body; the api-support cache populated by probe_api_client's own finished slot is the source of truth by the time the handler runs.

Also drops the now-unused ``NetworkResponse`` import.